### PR TITLE
Fixes #26

### DIFF
--- a/fixture.py
+++ b/fixture.py
@@ -158,6 +158,7 @@ class DMX_Fixture(PropertyGroup):
         self.objects.clear()
         self.channels.clear()
         self.virtual_channels.clear()
+        self.emitter_materials.clear()
 
         # Create clean Collection
         # (Blender creates the collection with selected objects/collections)


### PR DESCRIPTION
## Issues

- #26

## Description

When rebuilding the material list wasn't being cleared, which caused the earlier material references to break.