### PR TITLE
Volume Box fails on create and update

### DIFF
--- a/material.py
+++ b/material.py
@@ -60,7 +60,6 @@ def getVolumeScatterMaterial():
             for node in material.node_tree.nodes:
                 print(node)
 
-    material.node_tree.nodes.remove(material.node_tree.nodes[PRINCIPLED_BSDF])
     material.node_tree.nodes.new(SHADER_NODE_VOLUMESCATTER)
     material.node_tree.links.new(material.node_tree.nodes[MATERIAL_OUTPUT].inputs[1], material.node_tree.nodes[VOLUME_SCATTER].outputs[0])
     return material

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -53,17 +53,15 @@ class DMX_OT_Setup_Volume_Create(Operator):
             dmx.volume = bpy.data.objects["DMX_Volume"]
 
         dmx.volume_nodetree = dmx.volume.data.materials[0].node_tree
-        if (dmx.volume.name in bpy.context.scene.collection.objects):
-            bpy.ops.object.select_all(action='DESELECT')
-            dmx.volume.select_set(True)
-            bpy.ops.collection.objects_remove_all()
-
-        bpy.context.scene.collection.objects.link(dmx.volume)
+        
+        old_collections = dmx.volume.users_collection
+        if (dmx.collection not in old_collections):
+            dmx.collection.objects.link(dmx.volume)
+            for collection in old_collections:
+                collection.objects.unlink(dmx.volume)
 
         dmx.volume.location = pos
         dmx.volume.scale = scale
-
-
 
         return {'FINISHED'}
 
@@ -143,4 +141,5 @@ class DMX_PT_Setup(Panel):
     def draw(self, context):
         layout = self.layout
         dmx = context.scene.dmx
-        if (not dmx.collection): layout.operator("dmx.new_show", text="Create New Show", icon="LIGHT")
+        if (not dmx.collection):
+            layout.operator("dmx.new_show", text="Create New Show", icon="LIGHT")


### PR DESCRIPTION
## Description

There were a few issues with the `v1.0.0` `Volume Box` feature.

- When creating the material, it was trying to delete the "Principled BSDF" node twice.
- The object was wrongly linked to the scene collection, when it should remain inside the "DMX" collection, which caused errors on Update.