### PR TITLE
Add support for focus points during MVR import

### DIFF
--- a/fixture.py
+++ b/fixture.py
@@ -129,7 +129,7 @@ class DMX_Fixture(PropertyGroup):
         max = 1.0,
         default = (1.0,1.0,1.0,1.0))
 
-    def build(self, name, profile, mode, universe, address, gel_color, display_beams, mvr_position = None):
+    def build(self, name, profile, mode, universe, address, gel_color, display_beams, mvr_position = None, focus_point = None):
 
         # (Edit) Store objects positions
         old_pos = {obj.name:obj.object.location.copy() for obj in self.objects}
@@ -258,6 +258,12 @@ class DMX_Fixture(PropertyGroup):
             for obj in self.objects:
                 if obj.object.get("geometry_root", False):
                     obj.object.matrix_world=mvr_position
+
+        # Set target's position from MVR
+        if focus_point is not None:
+            for obj in self.objects:
+                if 'Target' in obj.name:
+                    obj.object.matrix_world=focus_point
 
         # Setup emitter
         for obj in self.collection.objects:


### PR DESCRIPTION
This updates pymvr, which now supports parsing of focus in fixtures and FocusPoints in scene. During import to BlenderDMX, this data is used to set the Target.