### PR TITLE
Improve MVR import speed by 2x

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -839,12 +839,8 @@ class DMX(PropertyGroup):
 
     def updatePreviewVolume(self):
         for fixture in self.fixtures:
-            if bpy.context.active_object is not None and bpy.context.active_object.name in fixture.collection.objects:
-                for light in fixture.lights:
-                    light.object.data.show_cone = self.volume_preview
-            else:
-                for light in fixture.lights:
-                    light.object.data.show_cone = False
+            for light in fixture.lights:
+                light.object.data.show_cone = self.volume_preview
 
     # # Universes
 

--- a/fixture.py
+++ b/fixture.py
@@ -337,8 +337,8 @@ class DMX_Fixture(PropertyGroup):
                     DMX_Data.set_virtual(self.name, attribute, value)
 
     def render(self):
-        if bpy.context.scene.dmx.mvr_import_in_progress:
-            # do not run dender loop during MVR import
+        if bpy.context.window_manager.dmx.pause_render:
+        # do not run dender loop during MVR import
             return
         channels = [c.id for c in self.channels]
         data = DMX_Data.get(self.universe, self.address, len(channels))

--- a/gdtf.py
+++ b/gdtf.py
@@ -9,6 +9,7 @@ import os
 import bpy
 import copy
 import math
+import hashlib
 
 from mathutils import Euler, Matrix
 
@@ -486,4 +487,8 @@ class DMX_GDTF():
     @staticmethod
     def getName(profile, dmx_mode, display_beams, add_target):
         revision = profile.revisions[-1].text if len(profile.revisions) else ''
-        return f"{profile.manufacturer}, {profile.name}, {dmx_mode}, {revision}, {'with_beams' if display_beams else 'without_beams'}, {'with_target' if add_target else 'without_target'}"
+        name = f"{profile.manufacturer}, {profile.name}, {dmx_mode}, {revision}, {'with_beams' if display_beams else 'without_beams'}, {'with_target' if add_target else 'without_target'}"
+        # base64 encode the name as collections seems to have lenght limit 
+        # which causes collections not to be cached, thus slowing imports down
+        name = hashlib.shake_256(name.encode()).hexdigest(5)
+        return name

--- a/gdtf.py
+++ b/gdtf.py
@@ -351,13 +351,16 @@ class DMX_GDTF():
             constraint.target = obj_child
             collection.objects.link(light_object)
         
-        def add_child_position(geometry):
+        def add_child_position(geometry, invertX = False):
             """Add a child, create a light source and emitter material for beams"""
 
             #if (not sanitize_obj_name(geometry) in objs): return
             obj_child = objs[sanitize_obj_name(geometry)]
             position = Matrix(geometry.position.matrix).to_translation()
-            obj_child.location[0] += (position[0]*-1) # a bug due to rotations of parents not being applied
+            if invertX:
+                obj_child.location[0] += (position[0]*-1) # still have not found the bug
+            else:
+                obj_child.location[0] += position[0]
             obj_child.location[1] += position[1]
             obj_child.location[2] += position[2]
 
@@ -404,7 +407,7 @@ class DMX_GDTF():
                 reference.name=sanitize_obj_name(geometry)
                 reference.position = geometry.position
 
-                add_child_position(reference)
+                add_child_position(reference, invertX=True)
 
                 if isinstance(reference, pygdtf.GeometryBeam):
                     create_beam(reference)
@@ -505,6 +508,8 @@ class DMX_GDTF():
             objs["2d_symbol"] = obj
             obj.show_in_front = True
             obj.active_material.grease_pencil.show_stroke = True
+            obj.data.pixel_factor = 2
+
             #svg.data.layers[...].frames[0].strokes[0]
             # add constraints
             constraint_copyLocation = obj.constraints.new(

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -281,6 +281,7 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
         scene = context.scene
         dmx = scene.dmx
         selected = scene.dmx.selectedFixtures()
+        context.window_manager.dmx.pause_render = True # pause renderer as partially imported fixture can cause issues during updates
         # Single fixture
         if (len(selected) == 1):
             fixture = selected[0]
@@ -288,6 +289,7 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
                 return {'CANCELLED'}
             if not self.re_address_only:
                 fixture.build(self.name, self.profile, self.mode, self.universe, self.address, self.gel_color, self.display_beams, self.add_target)
+                context.window_manager.dmx.pause_render = False
             else:
                 fixture.address = self.address
                 fixture.universe = self.universe
@@ -314,7 +316,7 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
                 else:
                     address += len(fixture.channels)
 
-
+        context.window_manager.dmx.pause_render = False # re-enable renderer
         return {'FINISHED'}
 
     def invoke(self, context, event):

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -128,7 +128,7 @@ class DMX_PT_Setup_Debug(Panel):
         layout = self.layout
         dmx = context.scene.dmx
         row = layout.row()
-        row.prop(context.scene.dmx, 'mvr_import_in_progress')
+        row.prop(context.window_manager.dmx, 'pause_render')
         row = layout.row()
         row.prop(context.scene.dmx,'display_2D')
         row = layout.row()


### PR DESCRIPTION
- move and rename the "mvr in progress" bool to a temporary object and rename it to "render pause", to better indicate it's meaning
- use the pausing of renderer during 2D view and also during GDTF fixture edits (to prevent render issue during partially imported state)
- use hashing for collection names as there seems to be a limit to collection names - this speeds up GDTF loading
- use caching during MVR import by creating a caching collection. 2x speed up achieved during import
- handle glb files composed of multiple models
- update switching to 2D to support Blender 4.x