### PR TITLE
Further mvr improvements - Create Fixture Groups from MVR...

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -209,7 +209,7 @@ class DMX(PropertyGroup):
 
     data_version: IntProperty(
             name = "BlenderDMX data version, bump when changing RNA structure and provide migration script",
-            default = 2,
+            default = 3,
             )
 
     # New DMX Scene
@@ -347,8 +347,22 @@ class DMX(PropertyGroup):
                         print("updating", obj.name)
                         obj.name = 'Root'
 
+        if file_data_version < 3:
+            print("Running migration 2→3")
+            dmx = bpy.context.scene.dmx
+
+            for fixture in dmx.fixtures:
+                if "uuid" not in fixture:
+                    print("Adding UUID to", fixture.name)
+                    fixture.uuid = str(uuid.uuid4())
+
+            for group in dmx.groups:
+                if "uuid" not in group:
+                    print("Adding UUID to", group.name)
+                    group.uuid = str(uuid.uuid4())
+
         # add here another if statement for next migration condition... like:
-        # if file_data_version < 3: #...
+        # if file_data_version < 4: #...
 
         self.collection["DMX_DataVersion"] = self.data_version # set data version to current
 
@@ -747,11 +761,11 @@ class DMX(PropertyGroup):
     # Kernel Methods
     # # Fixtures
 
-    def addFixture(self, name, profile, universe, address, mode, gel_color, display_beams, add_target, position=None, focus_point=None):
+    def addFixture(self, name, profile, universe, address, mode, gel_color, display_beams, add_target, position=None, focus_point=None, uuid = None):
         bpy.app.handlers.depsgraph_update_post.clear()
         dmx = bpy.context.scene.dmx
         dmx.fixtures.add()
-        dmx.fixtures[-1].build(name, profile, mode, universe, address, gel_color, display_beams, add_target, position, focus_point)
+        dmx.fixtures[-1].build(name, profile, mode, universe, address, gel_color, display_beams, add_target, position, focus_point, uuid)
         bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
 
     def removeFixture(self, fixture):

--- a/__init__.py
+++ b/__init__.py
@@ -613,6 +613,8 @@ class DMX(PropertyGroup):
     def onProgrammerDimmer(self, context):
         bpy.app.handlers.depsgraph_update_post.clear()
         for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
                     fixture.setDMX({
@@ -635,6 +637,8 @@ class DMX(PropertyGroup):
 
         bpy.app.handlers.depsgraph_update_post.clear()
         for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
                     rgb=[int(255*x) for x in self.programmer_color]
@@ -665,6 +669,8 @@ class DMX(PropertyGroup):
     def onProgrammerPan(self, context):
         bpy.app.handlers.depsgraph_update_post.clear()
         for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
                     fixture.setDMX({
@@ -683,6 +689,8 @@ class DMX(PropertyGroup):
     def onProgrammerTilt(self, context):
         bpy.app.handlers.depsgraph_update_post.clear()
         for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
                     fixture.setDMX({
@@ -694,6 +702,8 @@ class DMX(PropertyGroup):
     def onProgrammerZoom(self, context):
         bpy.app.handlers.depsgraph_update_post.clear()
         for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
                     fixture.setDMX({
@@ -705,6 +715,8 @@ class DMX(PropertyGroup):
     def onProgrammerShutter(self, context):
         bpy.app.handlers.depsgraph_update_post.clear()
         for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
                     fixture.setDMX({
@@ -750,7 +762,8 @@ class DMX(PropertyGroup):
         active = self.findFixture(bpy.context.active_object)
         if (not active): return
         data = active.getProgrammerData()
-        self.programmer_dimmer = data['Dimmer']/256.0
+        if 'Dimmer' in data:
+            self.programmer_dimmer = data['Dimmer']/256.0
         if 'Shutter1' in data:
             self.programmer_shutter = int(data['Shutter1']/256.0)
         if ('Zoom' in data):

--- a/__init__.py
+++ b/__init__.py
@@ -822,9 +822,18 @@ class DMX(PropertyGroup):
                 already_extracted_files,
                 layer_collection,
             )
+            self.clean_up_empty_mvr_collections(layer_collection)
+            if len(layer_collection.children) == 0:
+                bpy.context.scene.collection.children.unlink(layer_collection)
+
         bpy.context.window_manager.dmx.pause_render = False # re-enable render loop
         bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
         print("MVR scene loaded in %.4f sec." % (time.time() - star_time))
+
+    def clean_up_empty_mvr_collections(self,collections):
+        for collection in collections.children:
+            if len(collection.children) == 0:
+                collections.children.unlink(collection)
 
     def ensureUniverseExists(self, universe):
         # Allocate universes to be able to control devices

--- a/__init__.py
+++ b/__init__.py
@@ -40,6 +40,7 @@ from dmx.panels.programmer import *
 import dmx.panels.profiles as Profiles
 
 from dmx.preferences import DMX_Preferences
+from dmx.group import FixtureGroup
 
 from dmx.util import rgb_to_cmy, xyY2rgbaa
 
@@ -350,16 +351,18 @@ class DMX(PropertyGroup):
         if file_data_version < 3:
             print("Running migration 2→3")
             dmx = bpy.context.scene.dmx
-
+            print("Add UUID to fixtures")
             for fixture in dmx.fixtures:
                 if "uuid" not in fixture:
                     print("Adding UUID to", fixture.name)
                     fixture.uuid = str(uuid.uuid4())
-
+            print("Add UUID to groups, convert groups to json")
             for group in dmx.groups:
                 if "uuid" not in group:
                     print("Adding UUID to", group.name)
                     group.uuid = str(uuid.uuid4())
+                print("Migrating group")
+                group.dump = json.dumps([x[1:-1] for x in group.dump.strip('[]').split(', ')])
 
         # add here another if statement for next migration condition... like:
         # if file_data_version < 4: #...
@@ -817,7 +820,8 @@ class DMX(PropertyGroup):
             bpy.context.scene.collection.children.link(layer_collection)
 
             g_name = layer.name or "Layer"
-            fixture_group = f"{g_name} {layer_index}"
+            g_name = f"{g_name} {layer_index}"
+            fixture_group = FixtureGroup(g_name, layer.uuid)
 
             process_mvr_child_list(
                 self,

--- a/assets/primitives/thumbnail.svg
+++ b/assets/primitives/thumbnail.svg
@@ -1,0 +1,20 @@
+
+<svg height="238.000000mm" viewBox="-119.000000 -119.000000 238.000000 238.000000" width="238.000000mm" xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <g/>
+        <g>
+            <circle cx="0.000000" cy="-0.000000" fill="#000000" r="119.000000" stroke="#FFFFFF"/>
+        </g>
+        <g>
+            <circle cx="0.000000" cy="-0.000000" fill="#000000" r="86.755539" stroke="#FFFFFF"/>
+        </g>
+        <g>
+            <path d="M 0.000000 -0.000000L 61.345430 -61.345430" fill="None" stroke="#FFFFFF"/>
+        </g>
+        <g>
+            <path d="M 0.000000 -0.000000L -61.345430 -61.345430" fill="None" stroke="#FFFFFF"/>
+        </g>
+        <g/>
+        <g/>
+    </g>
+</svg>

--- a/fixture.py
+++ b/fixture.py
@@ -262,6 +262,9 @@ class DMX_Fixture(PropertyGroup):
                 self.objects.add()
                 self.objects[-1].name = "Head"
                 self.objects["Head"].object = links[obj.name]
+            elif obj.get("2d_symbol", None) == "all":
+                self.objects.add().name = "2D Symbol"
+                self.objects["2D Symbol"].object = links[obj.name]
 
             # Link all other object to collection
             self.collection.objects.link(links[obj.name])
@@ -324,6 +327,7 @@ class DMX_Fixture(PropertyGroup):
                 continue
             if obj.get("2d_symbol", None) == "all":
                 obj.hide_set(not bpy.context.scene.dmx.display_2D)
+                continue
 
             obj.hide_select = not bpy.context.scene.dmx.select_geometries
  
@@ -657,12 +661,36 @@ class DMX_Fixture(PropertyGroup):
         return params
 
     def select(self):
-        self.objects["Root"].object.select_set(True)
+        dmx = bpy.context.scene.dmx
+        if dmx.display_2D:
+            # in 2D view deselect the 2D symbol, unhide the fixture and select base, 
+            # to allow movement and rotation 
+            self.objects["2D Symbol"].object.select_set(False)
+
+            for obj in self.collection.objects:
+                if "pigtail" in obj.get("geometry_type", ""):
+                    obj.hide_set(not bpy.context.scene.dmx.display_pigtails)
+                if obj.get("2d_symbol", None):
+                    continue
+                obj.hide_set(False)
+            self.objects["Root"].object.select_set(True)
+
+        else:
+            self.objects["Root"].object.select_set(True)
     
     def unselect(self):
+        dmx = bpy.context.scene.dmx
         self.objects["Root"].object.select_set(False)
         if ('Target' in self.objects):
             self.objects['Target'].object.select_set(False)
+        if "2D Symbol" in self.objects:
+            self.objects["2D Symbol"].object.select_set(False)
+        if dmx.display_2D:
+            for obj in self.collection.objects:
+                if obj.get("2d_symbol", None):
+                    continue
+                obj.hide_set(True)
+
 
     def toggleSelect(self):
         selected = False

--- a/fixture.py
+++ b/fixture.py
@@ -8,6 +8,7 @@
 import bpy
 import math
 import mathutils
+import uuid
 
 from dmx.material import getEmitterMaterial
 from dmx.model import DMX_Model
@@ -130,6 +131,12 @@ class DMX_Fixture(PropertyGroup):
         default = 1,
         min = 1,
         max = 512)
+
+    uuid: StringProperty(
+        name = "UUID",
+        description = "Unique ID, used for MVR",
+        default = str(uuid.uuid4())
+            )
         
     display_beams: BoolProperty(
         name = "Display beams",
@@ -149,7 +156,7 @@ class DMX_Fixture(PropertyGroup):
         max = 1.0,
         default = (1.0,1.0,1.0,1.0))
 
-    def build(self, name, profile, mode, universe, address, gel_color, display_beams, add_target, mvr_position = None, focus_point = None):
+    def build(self, name, profile, mode, universe, address, gel_color, display_beams, add_target, mvr_position = None, focus_point = None, uuid = None):
 
         # (Edit) Store objects positions
         old_pos = {obj.name:obj.object.location.copy() for obj in self.objects}
@@ -286,6 +293,8 @@ class DMX_Fixture(PropertyGroup):
             for obj in self.objects:
                 if 'Target' in obj.name:
                     obj.object.matrix_world=focus_point
+        if uuid is not None:
+            self.uuid = uuid
 
         # Setup emitter
         for obj in self.collection.objects:

--- a/gdtf.py
+++ b/gdtf.py
@@ -115,12 +115,18 @@ class DMX_GDTF():
         obj = None
         if filename in profile._package.namelist():
             profile._package.extract(filename, extract_to_folder_path)
-            bpy.ops.wm.gpencil_import_svg(filepath="", directory=extract_to_folder_path, files=[{"name":filename}], scale=1)
-            if len(bpy.context.view_layer.objects.selected):
-                obj = bpy.context.view_layer.objects.selected[0]
-            if obj is not None:
-                obj.users_collection[0].objects.unlink(obj)
-                obj.rotation_euler[0]=-90*(math.pi/180)
+        else:
+            #default 2D
+            extract_to_folder_path = os.path.join(current_path, 'assets', 'primitives')
+            filename = "thumbnail.svg"
+
+        bpy.ops.wm.gpencil_import_svg(filepath="", directory=extract_to_folder_path, files=[{"name":filename}], scale=1)
+        if len(bpy.context.view_layer.objects.selected):
+            obj = bpy.context.view_layer.objects.selected[0]
+        if obj is not None:
+            obj.name = "2D symbol"
+            obj.users_collection[0].objects.unlink(obj)
+            obj.rotation_euler[0]=-90*(math.pi/180)
         return obj
 
     @staticmethod

--- a/group.py
+++ b/group.py
@@ -6,6 +6,7 @@
 #
 
 import bpy
+import uuid
 
 from bpy.props import (PointerProperty,
                        StringProperty,
@@ -25,6 +26,11 @@ class DMX_Group(PropertyGroup):
         name = "DMX Groups"
     )
 
+    uuid: StringProperty(
+        name = "UUID",
+        description = "Unique ID, used for MVR",
+        default = str(uuid.uuid4())
+            )
     # The current groups are stored and acessed here
     # I'm not sure this data is safe for use with Undo
     # Commenting until a veredict is reached

--- a/group.py
+++ b/group.py
@@ -7,6 +7,7 @@
 
 import bpy
 import uuid
+import json
 
 from bpy.props import (PointerProperty,
                        StringProperty,
@@ -50,7 +51,7 @@ class DMX_Group(PropertyGroup):
         # and repopulate it
         if (len(sel_fixtures)):
             #self.runtime[self.name] = sel_fixtures;
-            self.dump = str([fixture.name for fixture in sel_fixtures])
+            self.dump = json.dumps([fixture.name for fixture in sel_fixtures])
         else:
             self.dump = ''
 
@@ -60,10 +61,7 @@ class DMX_Group(PropertyGroup):
         # which seems to mess with the runtime volatile data declared as runtime
         # However, a better way should be considered (a Blender String Array)
         #for fixture in self.runtime[self.name]:
-        for fixture in self.rebuild():
+        fixtures = bpy.context.scene.dmx.fixtures
+        for fixture in [fixtures[fxt] for fxt in json.loads(self.dump)]:
             fixture.select()
 
-    def rebuild(self):
-        fixtures = bpy.context.scene.dmx.fixtures
-        #self.runtime[self.name] = [fixtures[fxt[1:-1]] for fxt in self.dump.strip('[]').split(', ')]
-        return [fixtures[fxt[1:-1]] for fxt in self.dump.strip('[]').split(', ')]

--- a/group.py
+++ b/group.py
@@ -19,10 +19,15 @@ from bpy.types import (ID,
 
 from dmx.fixture import *
 
+class FixtureGroup():
+    def __init__(self, name, uuid):
+        self.name = name
+        self.uuid = uuid
+
 class DMX_Group(PropertyGroup):
 
     # This is only used to save the group to file
-    # as a string representation of the fixture names array
+    # as a json representation of the fixture names array
     dump: StringProperty(
         name = "DMX Groups"
     )
@@ -56,6 +61,7 @@ class DMX_Group(PropertyGroup):
             self.dump = ''
 
     def select(self):
+        # Comment left here for legacy reasons. We now use json to serialize the array
         # Rebuilding the groups array everytime takes a long time
         # This was done to avoid inconsistencies on Undo of unrelated Operators,
         # which seems to mess with the runtime volatile data declared as runtime

--- a/mvr.py
+++ b/mvr.py
@@ -6,6 +6,7 @@ from mathutils import Matrix
 import time
 import hashlib
 import json
+from dmx.group import FixtureGroup
 
 
 # importing from dmx didn't work, had to duplicate this function
@@ -58,7 +59,8 @@ def process_mvr_child_list(
         )
         if fixture_group is None:
             g_name = truss_object.name or "Truss"
-            fixture_group = f"{g_name} {truss_index}"
+            g_name = f"{g_name} {truss_index}"
+            fixture_group = FixtureGroup(g_name, truss_object.uuid)
 
         if hasattr(truss_object, "child_list") and truss_object.child_list:
             process_mvr_child_list(
@@ -155,7 +157,8 @@ def process_mvr_child_list(
             # if group.child_list is not None:
             layer_group_index = f"{layer_index}-{group_index}"
             g_name = group.name or "Group"
-            fixture_group = f"{g_name} {group_index}"
+            g_name = f"{g_name} {group_index}"
+            fixture_group = FixtureGroup(g_name, group.uuid)
             process_mvr_child_list(
                 dmx,
                 group.child_list,
@@ -365,24 +368,19 @@ def add_mvr_fixture(
     )
     
     if fixture_group is not None:
-        print("process group", fixture_group)
         fixture_name = f"{fixture.name} {layer_index}-{fixture_index}"
         group = None
-        if fixture_group in dmx.groups:
-            print("found it", dmx.groups[fixture_group])
-            group = dmx.groups[fixture_group]
+        if fixture_group.name in dmx.groups:
+            group = dmx.groups[fixture_group.name]
         else:
             group = dmx.groups.add()
-            group.name = fixture_group
-        print("fixture name", fixture_name)
-        print("group", group.dump)
+            group.name = fixture_group.name
+            group.uuid = fixture_group.uuid
         if group.dump:
             dump = json.loads(group.dump)
         else:
             dump = []
-        print(type(dump), dump)
         dump.append(fixture_name)
-        print(dump, str(dump))
         group.dump = json.dumps(dump)
 
 

--- a/mvr.py
+++ b/mvr.py
@@ -348,4 +348,5 @@ def add_mvr_fixture(
         True,
         position=fixture.matrix.matrix,
         focus_point=focus_point,
+        uuid=fixture.uuid,
     )

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -10,6 +10,8 @@
 import bpy
 import os
 import shutil
+import uuid
+
 from dmx import pygdtf
 from dmx.gdtf import *
 import dmx.panels.profiles as Profiles
@@ -202,6 +204,11 @@ class DMX_Fixture_AddEdit():
         #update = onAddTarget,
         default = True)
 
+    uuid: StringProperty(
+        name = "UUID",
+        description = "Unique ID, used for MVR",
+        default = str(uuid.uuid4())
+            )
     re_address_only: BoolProperty(
         name = "Re-address only",
         description="Do not rebuild the model structure",
@@ -288,7 +295,7 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
             if (self.name != fixture.name and self.name in bpy.data.collections):
                 return {'CANCELLED'}
             if not self.re_address_only:
-                fixture.build(self.name, self.profile, self.mode, self.universe, self.address, self.gel_color, self.display_beams, self.add_target)
+                fixture.build(self.name, self.profile, self.mode, self.universe, self.address, self.gel_color, self.display_beams, self.add_target, uuid = self.uuid)
                 context.window_manager.dmx.pause_render = False
             else:
                 fixture.address = self.address
@@ -306,7 +313,7 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
                 profile = self.profile if (self.profile != '') else fixture.profile
                 mode = self.mode if (self.mode != '') else fixture.mode
                 if not self.re_address_only:
-                    fixture.build(name, profile, mode, self.universe, address, self.gel_color, self.display_beams, self.add_target)
+                    fixture.build(name, profile, mode, self.universe, address, self.gel_color, self.display_beams, self.add_target, uuid = self.uuid)
                 else:
                     fixture.address = address
                     fixture.universe = universe

--- a/panels/groups.py
+++ b/panels/groups.py
@@ -20,7 +20,7 @@ from bpy.types import (Panel,
 
 class DMX_UL_Group(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        icon = 'STICKY_UVS_LOC'
+        icon = "GROUP_VERTEX"
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             layout.label(text = item.name, icon = icon)
         elif self.layout_type in {'GRID'}:
@@ -154,4 +154,4 @@ class DMX_PT_Groups(Panel):
 
         layout.template_list("DMX_UL_Group", "", scene.dmx, "groups", scene.dmx, "group_list_i", rows=4)
 
-        layout.menu("DMX_MT_Group", text="...", icon="STICKY_UVS_LOC")
+        layout.menu("DMX_MT_Group", text="...", icon="GROUP_VERTEX")


### PR DESCRIPTION
- Create fixture groups from MVR
- Convert groups "dump" to json - much better serialization
- Add UUIDs to fixtures and groups
- Data version incremented, migrations added
- Clean up unused collections from MVR import
- Allow selection of 3D fixture after selecting it in 2D view to allow move/rotation
- Add default thumbnail to every fixture

All (hopefully) objects imported from MVR now have UUID for the future.