### PR TITLE
Fixture id properties

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -561,8 +561,8 @@ class DMX(PropertyGroup):
     # # DMX > ArtNet > Network Cards
 
     artnet_ipaddr : EnumProperty(
-        name = "Art-Net IPv4 Address",
-        description="The network card/interface to listen for ArtNet data",
+        name = "IPv4 Address",
+        description="The network card/interface to listen for Ethernet based DMX data",
         items = DMX_Network.cards()
     )
 

--- a/__init__.py
+++ b/__init__.py
@@ -788,11 +788,11 @@ class DMX(PropertyGroup):
     # Kernel Methods
     # # Fixtures
 
-    def addFixture(self, name, profile, universe, address, mode, gel_color, display_beams, add_target, position=None, focus_point=None, uuid = None):
+    def addFixture(self, name, profile, universe, address, mode, gel_color, display_beams, add_target, position=None, focus_point=None, uuid = None, fixture_id="", custom_id=0, fixture_id_numeric=0, unit_number=0):
         bpy.app.handlers.depsgraph_update_post.clear()
         dmx = bpy.context.scene.dmx
         dmx.fixtures.add()
-        dmx.fixtures[-1].build(name, profile, mode, universe, address, gel_color, display_beams, add_target, position, focus_point, uuid)
+        dmx.fixtures[-1].build(name, profile, mode, universe, address, gel_color, display_beams, add_target, position, focus_point, uuid, fixture_id, custom_id, fixture_id_numeric, unit_number)
         bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
 
     def removeFixture(self, fixture):

--- a/__init__.py
+++ b/__init__.py
@@ -241,7 +241,15 @@ class DMX(PropertyGroup):
         bpy.context.scene.collection.children.link(collection)
 
         # Set background to black (so it match the panel)
-        bpy.context.scene.world.node_tree.nodes['Background'].inputs[0].default_value = (0,0,0,0)
+        scene = bpy.context.scene
+
+        if scene.world is None:
+            # create a new world
+            new_world = bpy.data.worlds.new("New World")
+            new_world.use_nodes = True
+            scene.world = new_world
+
+        scene.world.node_tree.nodes['Background'].inputs[0].default_value = (0,0,0,0)
 
         # Create a DMX universe
         self.addUniverse()

--- a/__init__.py
+++ b/__init__.py
@@ -139,6 +139,7 @@ class DMX(PropertyGroup):
                 DMX_OT_Programmer_SelectBodies,
                 DMX_OT_Programmer_SelectTargets,
                 DMX_OT_Programmer_SelectCamera,
+                DMX_OT_Programmer_TargetsToZero,
                 DMX_PT_Programmer)
 
     linkedToFile = False
@@ -988,7 +989,6 @@ def onActiveChanged(*args):
                 fixture.unselect()
         if selected:
             bpy.context.window_manager.dmx.pause_render = False
-            print("unpause")
         else:
             bpy.context.window_manager.dmx.pause_render = True
 

--- a/__init__.py
+++ b/__init__.py
@@ -141,6 +141,7 @@ class DMX(PropertyGroup):
                 DMX_OT_Programmer_SelectTargets,
                 DMX_OT_Programmer_SelectCamera,
                 DMX_OT_Programmer_TargetsToZero,
+                DMX_PT_Fixture_Columns_Setup,
                 DMX_PT_Programmer)
 
     linkedToFile = False
@@ -159,6 +160,27 @@ class DMX(PropertyGroup):
                 bpy.utils.unregister_class(cls)
 
     # Blender RNA Properties
+
+    # fixture listing columns
+    column_fixture_id: BoolProperty(
+        name = "Fixture ID",
+        default = True)
+
+    column_unit_number: BoolProperty(
+        name = "Unit Number",
+        default = False)
+
+    column_custom_id: BoolProperty(
+        name = "Custom ID",
+        default = False)
+
+    column_fixture_id_numeric: BoolProperty(
+        name = "Fixture ID Numeric",
+        default = False)
+
+    column_dmx_address: BoolProperty(
+        name = "DMX Address",
+        default = True)
 
     collection: PointerProperty(
         name = "DMX Collection",

--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,7 @@ import atexit
 from operator import attrgetter
 from threading import Timer
 import time
+import json
 
 from dmx.pymvr import GeneralSceneDescription
 from dmx.mvr import extract_mvr_textures, process_mvr_child_list
@@ -796,6 +797,7 @@ class DMX(PropertyGroup):
         bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
 
     def removeFixture(self, fixture):
+        self.remove_fixture_from_groups(fixture.name)
         for obj in fixture.collection.objects:
             bpy.data.objects.remove(obj)
         for obj in fixture.objects:
@@ -901,6 +903,14 @@ class DMX(PropertyGroup):
 
     def removeGroup(self, i):
         bpy.context.scene.dmx.groups.remove(i)
+
+    def remove_fixture_from_groups(self, fixture_name):
+        dmx = bpy.context.scene.dmx
+        for group in dmx.groups:
+            dump = json.loads(group.dump)
+            if fixture_name in dump:
+                dump.remove(fixture_name)
+                group.dump = json.dumps(dump)
 
     # # Preview Volume
 

--- a/fixture.py
+++ b/fixture.py
@@ -694,7 +694,6 @@ class DMX_Fixture(PropertyGroup):
         return params
 
     def select(self):
-        print("fixture", self.name, "id", self.fixture_id)
         dmx = bpy.context.scene.dmx
         if dmx.display_2D:
             # in 2D view deselect the 2D symbol, unhide the fixture and select base, 

--- a/fixture.py
+++ b/fixture.py
@@ -138,6 +138,30 @@ class DMX_Fixture(PropertyGroup):
         default = str(uuid.uuid4())
             )
         
+    fixture_id: StringProperty(
+        name = "FixtureID",
+        description = "The Fixture ID is an identifier for the instance of this fixture that can be used to activate / select them for programming.",
+        default = ""
+            )
+
+    unit_number: IntProperty(
+        name = "UnitNumber",
+        description = "The identification of a fixture on its position. Use this as an alternative numbering scheme if the planning and programming numbering is different.",
+        default = 0
+            )
+
+    fixture_id_numeric: IntProperty(
+        name = "FixtureIDNumeric",
+        description = "The Fixture ID is an identifier for the instance of this fixture that can be used to activate / select them for programming.",
+        default = 0
+            )
+
+    custom_id: IntProperty(
+        name = "CustomId",
+        description = "The Fixture ID is an identifier for the instance of this fixture that can be used to activate / select them for programming.",
+        default = 0
+            )
+
     display_beams: BoolProperty(
         name = "Display beams",
         description="Display beam projection and cone",
@@ -156,7 +180,8 @@ class DMX_Fixture(PropertyGroup):
         max = 1.0,
         default = (1.0,1.0,1.0,1.0))
 
-    def build(self, name, profile, mode, universe, address, gel_color, display_beams, add_target, mvr_position = None, focus_point = None, uuid = None):
+    def build(self, name, profile, mode, universe, address, gel_color, display_beams, add_target, mvr_position = None, 
+              focus_point = None, uuid = None, fixture_id="", custom_id=0, fixture_id_numeric=0, unit_number=0):
 
         # (Edit) Store objects positions
         old_pos = {obj.name:obj.object.location.copy() for obj in self.objects}
@@ -172,6 +197,16 @@ class DMX_Fixture(PropertyGroup):
         self.name = name
         self.profile = profile
         self.mode = mode
+        if fixture_id is not None:
+            self.fixture_id = fixture_id
+        if custom_id is not None:
+            self.custom_id = custom_id
+        if fixture_id_numeric is not None:
+            self.fixture_id_numeric = fixture_id_numeric
+        if unit_number is not None:
+            self.unit_number = unit_number
+        if uuid is not None:
+            self.uuid = uuid
 
         # DMX Properties
         self.universe = universe
@@ -296,8 +331,6 @@ class DMX_Fixture(PropertyGroup):
             for obj in self.objects:
                 if 'Target' in obj.name:
                     obj.object.matrix_world=focus_point
-        if uuid is not None:
-            self.uuid = uuid
 
         # Setup emitter
         for obj in self.collection.objects:
@@ -661,6 +694,7 @@ class DMX_Fixture(PropertyGroup):
         return params
 
     def select(self):
+        print("fixture", self.name, "id", self.fixture_id)
         dmx = bpy.context.scene.dmx
         if dmx.display_2D:
             # in 2D view deselect the 2D symbol, unhide the fixture and select base, 

--- a/mvr.py
+++ b/mvr.py
@@ -32,16 +32,7 @@ def onDepsgraph(scene):
                 break
 
 
-def process_mvr_child_list(
-    dmx,
-    child_list,
-    layer_index,
-    extract_to_folder_path,
-    mvr_scene,
-    already_extracted_files,
-    layer_collection,
-    fixture_group = None
-):
+def process_mvr_child_list(dmx, child_list, layer_index, extract_to_folder_path, mvr_scene, already_extracted_files, layer_collection, fixture_group=None):
     if "MVR Trusses" in layer_collection:
         truss_collection = layer_collection["MVR Trusses"]
     else:
@@ -110,16 +101,7 @@ def process_mvr_child_list(
         )
 
         if hasattr(scene_object, "child_list") and scene_object.child_list:
-            process_mvr_child_list(
-                dmx,
-                scene_object.child_list,
-                scene_index,
-                extract_to_folder_path,
-                mvr_scene,
-                already_extracted_files,
-                layer_collection,
-                fixture_group
-            )
+            process_mvr_child_list(dmx, scene_object.child_list, scene_index, extract_to_folder_path, mvr_scene, already_extracted_files, layer_collection, fixture_group)
 
     for fixture_index, fixture in enumerate(child_list.fixtures):
         focus_point = None
@@ -137,20 +119,11 @@ def process_mvr_child_list(
             layer_index,
             focus_point,
             already_extracted_files,
-            fixture_group
+            fixture_group,
         )
 
         if hasattr(fixture, "child_list") and fixture.child_list:
-            process_mvr_child_list(
-                dmx,
-                fixture.child_list,
-                fixture_index,
-                extract_to_folder_path,
-                mvr_scene,
-                already_extracted_files,
-                layer_collection,
-                fixture_group
-            )
+            process_mvr_child_list(dmx, fixture.child_list, fixture_index, extract_to_folder_path, mvr_scene, already_extracted_files, layer_collection, fixture_group)
 
     for group_index, group in enumerate(child_list.group_objects):
         if hasattr(group, "child_list") and group.child_list:
@@ -339,7 +312,7 @@ def add_mvr_fixture(
     layer_index,
     focus_point,
     already_extracted_files,
-    fixture_group = None,
+    fixture_group=None,
 ):
     """Add fixture to the scene"""
     if f"{fixture.gdtf_spec}" in mvr_scene._package.namelist():
@@ -365,8 +338,12 @@ def add_mvr_fixture(
         position=fixture.matrix.matrix,
         focus_point=focus_point,
         uuid=fixture.uuid,
+        fixture_id=fixture.fixture_id,
+        custom_id=fixture.custom_id,
+        fixture_id_numeric=fixture.fixture_id_numeric,
+        unit_number=fixture.unit_number,
     )
-    
+
     if fixture_group is not None:
         fixture_name = f"{fixture.name} {layer_index}-{fixture_index}"
         group = None
@@ -382,11 +359,3 @@ def add_mvr_fixture(
             dump = []
         dump.append(fixture_name)
         group.dump = json.dumps(dump)
-
-
-
-
-
-
-
-        

--- a/panels/dmx.py
+++ b/panels/dmx.py
@@ -71,7 +71,7 @@ class DMX_OT_Network_Card(Operator):
 
     ip_addr: StringProperty(
         name = "IPv4",
-        description = "ArtNet IPv4 Address",
+        description = "IPv4 Address",
         default = ""
     )
 

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -481,6 +481,35 @@ class DMX_OT_Fixture_Item(Operator):
         context.fixture.toggleSelect()
         return {'FINISHED'}
 
+
+
+class DMX_PT_Fixture_Columns_Setup(Panel):
+    bl_label = "Display Columns"
+    bl_idname = "DMX_PT_Fixture_Columns_Setup"
+    bl_parent_id = "DMX_PT_Fixtures"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "DMX"
+    bl_context = "objectmode"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        dmx = context.scene.dmx
+
+        row = layout.row()
+        row.prop(dmx, "column_fixture_id")
+        row = layout.row()
+        row.prop(dmx, "column_custom_id")
+        row = layout.row()
+        row.prop(dmx, "column_fixture_id_numeric")
+        row = layout.row()
+        row.prop(dmx, "column_unit_number")
+        row = layout.row()
+        row.prop(dmx, "column_dmx_address")
+
+
+
 class DMX_PT_Fixtures(Panel):
     bl_label = "Fixtures"
     bl_idname = "DMX_PT_Fixtures"
@@ -508,13 +537,29 @@ class DMX_PT_Fixtures(Panel):
                 row.context_pointer_set("fixture", fixture)
                 row.operator('dmx.fixture_item', text=fixture.name, depress=selected, icon='OUTLINER_DATA_LIGHT')
 
-                if fixture.fixture_id:
+                if dmx.column_fixture_id:
                     c = row.column()
                     c.label(text=f"{fixture.fixture_id}")
                     c.ui_units_x = 2
 
-                c = row.column()
-                c.label(text=f"{fixture.universe}.{fixture.address}")
-                c.ui_units_x = 2
+                if dmx.column_unit_number:
+                    c = row.column()
+                    c.label(text=f"{fixture.unit_number}")
+                    c.ui_units_x = 2
+
+                if dmx.column_fixture_id_numeric:
+                    c = row.column()
+                    c.label(text=f"{fixture.fixture_id_numeric}")
+                    c.ui_units_x = 2
+
+                if dmx.column_custom_id:
+                    c = row.column()
+                    c.label(text=f"{fixture.custom_id}")
+                    c.ui_units_x = 2
+
+                if dmx.column_dmx_address:
+                    c = row.column()
+                    c.label(text=f"{fixture.universe}.{fixture.address}")
+                    c.ui_units_x = 2
             
         layout.menu('DMX_MT_Fixture', text="Fixtures", icon="OUTLINER_DATA_LIGHT")

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -99,7 +99,8 @@ class DMX_MT_Fixture_Profiles(Menu):
         for profile in DMX_GDTF.getProfileList(manufacturer.name):
             row = layout.row()
             row.context_pointer_set("add_edit_panel", context.add_edit_panel)
-            row.operator(DMX_OT_Fixture_Profiles.bl_idname, text=profile[1].replace("_"," ")).profile = profile[0]
+            revision = f" ({profile[2]})" if profile[2] else ""
+            row.operator(DMX_OT_Fixture_Profiles.bl_idname, text=f"{profile[1]}{revision}".replace('_',' ')).profile = profile[0]
 
 class DMX_MT_Fixture_Mode(Menu):
     bl_label = "DMX > Fixture > Add > Mode"


### PR DESCRIPTION
- add Fixture ID and other related MVR fields to Fixture. This is essential for the future when re-loading MVR files.
- allow quick grouping of selected targets, to point devices to one location
- improve models loading, to support another 3 specific fixture manufacturers' models specifics
- handle situation if World is missing in user workspace
- remove fixture from groups when removing fixture
- display fixture revision in fixture list of patching menu
-  Add Fixture ID... as columns in Fixture list, allow select visible columns