### PR TITLE
Improve groups

### DIFF
--- a/group.py
+++ b/group.py
@@ -56,8 +56,7 @@ class DMX_Group(PropertyGroup):
         # and repopulate it
         if (len(sel_fixtures)):
             #self.runtime[self.name] = sel_fixtures;
-            # TODO: it would be better to use fixture UUID
-            self.dump = json.dumps([fixture.name for fixture in sel_fixtures])
+            self.dump = json.dumps([fixture.uuid for fixture in sel_fixtures])
         else:
             self.dump = ''
 
@@ -68,13 +67,14 @@ class DMX_Group(PropertyGroup):
         # which seems to mess with the runtime volatile data declared as runtime
         # However, a better way should be considered (a Blender String Array)
         #for fixture in self.runtime[self.name]:
-        fixtures = bpy.context.scene.dmx.fixtures
+        dmx = bpy.context.scene.dmx
 
         if not bpy.context.window_manager.dmx.aditive_selection:
             bpy.ops.object.select_all(action='DESELECT')
             bpy.context.scene.dmx.updatePreviewVolume()
 
-        for fixture in [fixtures[fxt] for fxt in json.loads(self.dump)]:
-            fixture.select()
+        for fixture in [dmx.findFixtureByUUID(f_uuid) for f_uuid in json.loads(self.dump)]:
+            if fixture is not None:
+                fixture.select()
         bpy.context.scene.dmx.updatePreviewVolume()
 

--- a/mvr.py
+++ b/mvr.py
@@ -401,8 +401,6 @@ def add_mvr_fixture(
         )
 
     if fixture_group is not None:
-        fixture_name = f"{fixture.name} {layer_index}-{fixture_index}"
-        group = None
         if fixture_group.name in dmx.groups:
             group = dmx.groups[fixture_group.name]
         else:
@@ -413,5 +411,5 @@ def add_mvr_fixture(
             dump = json.loads(group.dump)
         else:
             dump = []
-        dump.append(fixture_name)
+        dump.append(fixture.uuid_number)
         group.dump = json.dumps(dump)

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -298,7 +298,6 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
         dmx = scene.dmx
         selected = scene.dmx.selectedFixtures()
         context.window_manager.dmx.pause_render = True # pause renderer as partially imported fixture can cause issues during updates
-        # TODO: handle re-grouping if fixture name changed
         # Single fixture
         if (len(selected) == 1):
             fixture = selected[0]


### PR DESCRIPTION
When renaming fixtures, groups would be no longer working. This fixes it and improves the handling of UUIDs.