### PR TITLE
Fixture selection previous/next by keyboard

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -152,6 +152,7 @@ class DMX(PropertyGroup):
                 DMX_OT_Programmer_Set_Ignore_Movement,
                 DMX_OT_Programmer_Unset_Ignore_Movement,
                 DMX_PT_DMX_OSC,
+                DMX_OT_Fixture_ForceRemove,
                 DMX_PT_Programmer)
 
     linkedToFile = False
@@ -191,6 +192,10 @@ class DMX(PropertyGroup):
     column_dmx_address: BoolProperty(
         name = "DMX Address",
         default = True)
+
+    column_fixture_remove: BoolProperty(
+        name = "Remove Fixture",
+        default = False)
 
     collection: PointerProperty(
         name = "DMX Collection",

--- a/fixture.py
+++ b/fixture.py
@@ -767,6 +767,8 @@ class DMX_Fixture(PropertyGroup):
 
 
     def get_root(self, model_collection):
+        if model_collection.objects is None:
+            return None
         for obj in model_collection.objects:
             if obj.get("geometry_root", False):
                 return obj
@@ -815,7 +817,8 @@ class DMX_Fixture(PropertyGroup):
     
     def unselect(self):
         dmx = bpy.context.scene.dmx
-        self.objects["Root"].object.select_set(False)
+        if "Root" in self.objects:
+            self.objects["Root"].object.select_set(False)
         if ('Target' in self.objects):
             self.objects['Target'].object.select_set(False)
         if "2D Symbol" in self.objects:

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -206,11 +206,6 @@ class DMX_Fixture_AddEdit():
         #update = onAddTarget,
         default = True)
 
-    uuid: StringProperty(
-        name = "UUID",
-        description = "Unique ID, used for MVR",
-        default = str(py_uuid.uuid4())
-            )
     re_address_only: BoolProperty(
         name = "Re-address only",
         description="Do not rebuild the model structure",
@@ -232,7 +227,8 @@ class DMX_Fixture_AddEdit():
     def draw(self, context):
         layout = self.layout
         col = layout.column()
-        col.prop(self, "name")
+        if not self.re_address_only:
+            col.prop(self, "name")
         col.context_pointer_set("add_edit_panel", self)
         text_profile = "GDTF Profile"
         if (self.profile != ""):
@@ -241,11 +237,13 @@ class DMX_Fixture_AddEdit():
                 text_profile = text_profile[0] + " > " + text_profile[1]
             else:
                 text_profile = "Unknown manufacturer" + " > " + text_profile[0]
-        col.menu("DMX_MT_Fixture_Manufacturers", text = text_profile)
+        if not self.re_address_only:
+            col.menu("DMX_MT_Fixture_Manufacturers", text = text_profile)
         text_mode = "DMX Mode"
         if (self.mode != ""):
             text_mode = self.mode
-        col.menu("DMX_MT_Fixture_Mode", text = text_mode)
+        if not self.re_address_only:
+            col.menu("DMX_MT_Fixture_Mode", text = text_mode)
         col.prop(self, "universe")
         col.prop(self, "address")
         col.prop(self, "fixture_id")

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -300,6 +300,7 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
         if (len(selected) == 1):
             fixture = selected[0]
             if (self.name != fixture.name and self.name in bpy.data.collections):
+                self.report({'ERROR'}, "Fixture named " + self.name + " already exists")
                 return {'CANCELLED'}
             if not self.re_address_only:
                 fixture.build(self.name, self.profile, self.mode, self.universe, self.address, self.gel_color, self.display_beams, self.add_target, uuid = fixture.uuid, fixture_id = fixture.fixture_id)
@@ -318,6 +319,7 @@ class DMX_OT_Fixture_Edit(Operator, DMX_Fixture_AddEdit):
             for i, fixture in enumerate(selected):
                 name = self.name + ' ' + str(i+1)
                 if (name != fixture.name and name in bpy.data.collections):
+                    self.report({'ERROR'}, "Fixture named " + self.name + " already exists")
                     return {'CANCELLED'}
             for i, fixture in enumerate(selected):
                 name = (self.name + ' ' + str(i+1)) if (self.name != '*') else fixture.name
@@ -489,6 +491,17 @@ class DMX_OT_Fixture_Item(Operator):
         return {'FINISHED'}
 
 
+class DMX_OT_Fixture_ForceRemove(Operator):
+    bl_label = ""
+    bl_idname = "dmx.force_remove_fixture"
+    bl_description = "Remove fixture"
+    bl_options = {'UNDO'}
+
+    def execute(self, context):
+        print("Removing fixture", context.fixture)
+        dmx = context.scene.dmx
+        dmx.removeFixture(context.fixture)
+        return {'FINISHED'}
 
 class DMX_PT_Fixture_Columns_Setup(Panel):
     bl_label = "Display Columns"
@@ -514,6 +527,8 @@ class DMX_PT_Fixture_Columns_Setup(Panel):
         row.prop(dmx, "column_unit_number")
         row = layout.row()
         row.prop(dmx, "column_dmx_address")
+        row = layout.row()
+        row.prop(dmx, "column_fixture_remove")
         row = layout.row()
         row.prop(dmx, "fixtures_sorting_order")
 
@@ -586,5 +601,8 @@ class DMX_PT_Fixtures(Panel):
                     c = row.column()
                     c.label(text=f"{fixture.universe}.{fixture.address}")
                     c.ui_units_x = 2
+
+                if dmx.column_fixture_remove:
+                    row.operator('dmx.force_remove_fixture', icon="CANCEL")
             
         layout.menu('DMX_MT_Fixture', text="Fixtures", icon="OUTLINER_DATA_LIGHT")

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -480,6 +480,56 @@ class DMX_OT_Fixture_Import_MVR(Operator):
 
 # Panel #
 
+class DMX_OT_Fixture_SelectPrevious(Operator):
+    bl_label = " "
+    bl_idname = "dmx.fixture_previous"
+    bl_description = "Select Previous Fixture"
+    bl_options = {'UNDO'}
+
+    def execute(self, context):
+        scene = context.scene
+        dmx = scene.dmx
+        selected_all = dmx.selectedFixtures()
+        fixtures = dmx.sortedFixtures()
+
+        for fixture in fixtures:
+            fixture.unselect()
+
+        for selected in selected_all:
+            for idx, fixture in enumerate(fixtures):
+                if fixture == selected:
+                    idx -= 1
+                    if idx < 0:
+                        idx = len(fixtures)-1
+                    fixtures[idx].select()
+                    break
+        return {'FINISHED'}
+
+class DMX_OT_Fixture_SelectNext(Operator):
+    bl_label = " "
+    bl_idname = "dmx.fixture_next"
+    bl_description = "Select Next Fixture"
+    bl_options = {'UNDO'}
+
+    def execute(self, context):
+        scene = context.scene
+        dmx = scene.dmx
+        selected_all = dmx.selectedFixtures()
+        fixtures = dmx.sortedFixtures()
+
+        for fixture in fixtures:
+            fixture.unselect()
+
+        for selected in selected_all:
+            for idx, fixture in enumerate(fixtures):
+                if fixture == selected:
+                    idx += 1
+                    if idx > len(fixtures)-1:
+                        idx = 0
+                    fixtures[idx].select()
+                    break
+        return {'FINISHED'}
+
 class DMX_OT_Fixture_Item(Operator):
     bl_label = "DMX > Fixture > Item"
     bl_idname = "dmx.fixture_item"
@@ -543,9 +593,6 @@ class DMX_PT_Fixtures(Panel):
     bl_context = "objectmode"
 
     def draw(self, context):
-        def string_to_pairs(s, pairs=re.compile(r"(\D*)(\d*)").findall):
-            return [(text.lower(), int(digits or 0)) for (text, digits) in pairs(s)[:-1]]
-
         layout = self.layout
         scene = context.scene
         dmx = scene.dmx
@@ -553,18 +600,7 @@ class DMX_PT_Fixtures(Panel):
         if (len(scene.dmx.fixtures)):
             box = layout.box()
             col = box.column()
-            sorting_order = dmx.fixtures_sorting_order
-
-            if sorting_order == "ADDRESS":
-                fixtures = sorted(dmx.fixtures, key=lambda c: string_to_pairs(str(c.universe*1000+c.address)))
-            elif sorting_order == "NAME":
-                fixtures = sorted(dmx.fixtures, key=lambda c: string_to_pairs(c.name))
-            elif sorting_order == "FIXTURE_ID":
-                fixtures = sorted(dmx.fixtures, key=lambda c: string_to_pairs(str(c.fixture_id)))
-            elif sorting_order == "UNIT_NUMBER":
-                fixtures = sorted(dmx.fixtures, key=lambda c: string_to_pairs(str(c.unit_number)))
-            else:
-                fixtures = dmx.fixtures
+            fixtures = dmx.sortedFixtures()
 
             for fixture in fixtures:
                 selected = False

--- a/panels/groups.py
+++ b/panels/groups.py
@@ -8,6 +8,7 @@
 #
 
 import bpy
+import json
 
 from bpy.props import (StringProperty)
 
@@ -21,8 +22,9 @@ from bpy.types import (Panel,
 class DMX_UL_Group(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         icon = "GROUP_VERTEX"
+        fixture_count = len(json.loads(item.dump))
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
-            layout.label(text = item.name, icon = icon)
+            layout.label(text = f"{item.name} ({fixture_count})", icon = icon)
         elif self.layout_type in {'GRID'}:
             layout.alignment = 'CENTER'
             layout.label(text="", icon = icon)


### PR DESCRIPTION
- allow changing fixture selection with Ctrl-Left, Ctrl-Right keyabord shortcuts
- add possibility to remove fixture added in a faulty state
- show number of devices in a group
- improve the "Re-address only" dialog to only show fields which will be used

