### PR TITLE
Custom BlenderDMX namespace driver

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1374,6 +1374,14 @@ def onLoadFile(scene):
     DMX_MVR_X_Protocol.disable()
     DMX_Zeroconf.disable()
 
+    # register a "bdmxX" namespace to get current value of a DMX channel,
+    # the syntax is #bdmxX(universe, address), where X is c or f (coarse, fine)
+    # for example: #bdmxc(1,1)
+    data_get_coarse = DMX_Data.get_coarse
+    data_get_fine = DMX_Data.get_fine
+    bpy.app.driver_namespace['bdmxc'] = data_get_coarse
+    bpy.app.driver_namespace['bdmxf'] = data_get_fine
+
 @bpy.app.handlers.persistent
 def onUndo(scene):
     if (not scene.dmx.collection and DMX.linkedToFile):

--- a/data.py
+++ b/data.py
@@ -65,6 +65,18 @@ class DMX_Data():
                 DMX_Data._universes.append(bytearray([0]*512))
                 print("DMX", "Universe Allocated: ", u)
 
+    @staticmethod
+    def get_coarse(universe, addr):
+        """Used for the namespace bdmxc function 
+        Returns single 8bit value """
+        return DMX_Data.get(universe, addr, 1)[0]
+
+    @staticmethod
+    def get_fine(universe, addr):
+        """Used for the namespace bdmxf function
+        Returns single 16bit value"""
+        data = DMX_Data.get(universe, addr, 2)
+        return data[0]*256+data[1]
 
     @staticmethod
     def get(universe, addr, n):


### PR DESCRIPTION
Add custom namespace driver for Blender, to use DMX for general animations.

One can add: `#bdmxc(1,1)` to any field in Blender to receive first address of first universe as a value for this field.
The syntax is #bdmxX(universe, address), where X is c or f (coarse, fine)
