### PR TITLE
Make setting universes more understandable

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1370,11 +1370,12 @@ def onDepsgraph(scene):
 
 @bpy.app.handlers.persistent
 def onLoadFile(scene):
-    if ('DMX' in bpy.data.scenes['Scene'].collection.children):
-        print("DMX", "File contains DMX show, linking...")
-        bpy.context.scene.dmx.linkFile()
-    else:
-        bpy.context.scene.dmx.unlinkFile()
+    if "Scene" in bpy.data.scenes:
+        if ('DMX' in bpy.data.scenes['Scene'].collection.children):
+            print("DMX", "File contains DMX show, linking...")
+            bpy.context.scene.dmx.linkFile()
+        else:
+            bpy.context.scene.dmx.unlinkFile()
 
     # Selection callback
     handle = object()

--- a/__init__.py
+++ b/__init__.py
@@ -270,16 +270,25 @@ class DMX(PropertyGroup):
         # Clear the buffer on change of every protocol
         DMX_Data.prepare_empty_buffer()
 
-    selected_live_dmx_source : EnumProperty(
-        name = "DMX Source",
-        description="The network protocol for which to show live DMX values",
-        default = "BLENDERDMX",
-        items = network_options_list,
-        update = prepare_empty_buffer,
-    )
-    selected_live_dmx_universe: IntProperty(
-        min = 0,
-        update = prepare_empty_buffer,
+
+    def get_dmx_universes(self, context):
+        #print(self, context)
+        data = []
+        for universe in self.universes:
+            data.append((str(universe.id), universe.name, str(universe.input), "", universe.id))
+        return data
+
+    def get_selected_live_dmx_universe(self):
+        for universe in self.universes:
+            selected_universe = universe
+            if self.selected_live_dmx == str(universe.id):
+                break
+        return selected_universe
+
+    selected_live_dmx: EnumProperty(
+        name = "Universe",
+        description="",
+        items = get_dmx_universes
     )
 
     dmx_values: CollectionProperty(
@@ -1319,7 +1328,7 @@ class DMX(PropertyGroup):
 
     def addUniverse(self):
         id = len(self.universes)
-        DMX_Universe.add(self, id, "DMX %d"%id)
+        DMX_Universe.add(self, id, "Universe %d"%id)
 
     def removeUniverse(self, i):
         DMX_Universe.remove(self, i)

--- a/data.py
+++ b/data.py
@@ -141,6 +141,5 @@ class DMX_Data():
                         except Exception as e:
                             print(e)
                     DMX_Data._last_updated = time.time()
-                    print("update dmx")
 
         return changed

--- a/data.py
+++ b/data.py
@@ -95,10 +95,9 @@ class DMX_Data():
         if addr > 511:
             return
 
-
         if DMX_Data._dmx is not None:
             dmx = DMX_Data._dmx
-            if dmx.selected_live_dmx_source == "BLENDERDMX":
+            if dmx.get_selected_live_dmx_universe().input == "BLENDERDMX":
                 dmx = bpy.context.scene.dmx
                 dmx.dmx_values[addr-1].channel=val
         DMX_Data._universes[universe][addr-1] = val
@@ -132,7 +131,8 @@ class DMX_Data():
 
         if DMX_Data._dmx is not None:
             dmx = DMX_Data._dmx
-            if dmx.selected_live_dmx_source == source and dmx.selected_live_dmx_universe == universe:
+            selected_live_dmx_universe = dmx.get_selected_live_dmx_universe()
+            if selected_live_dmx_universe.input == source and selected_live_dmx_universe.id == universe:
                 if DMX_Data._last_updated is None or (time.time() - DMX_Data._last_updated > 0.8 and changed):
                     # We limit update by time, too fast updates were troubling Blender's UI
                     for idx, val in enumerate(data):

--- a/fixture.py
+++ b/fixture.py
@@ -123,12 +123,18 @@ class DMX_Fixture(PropertyGroup):
         type = DMX_Fixture_Channel
     )
 
+    def ensure_universe_exists(self, context):
+        dmx = bpy.context.scene.dmx
+        dmx.ensureUniverseExists(self.universe)
+
     universe : IntProperty(
         name = "Fixture > Universe",
         description="Fixture DMX Universe",
         default = 0,
         min = 0,
-        max = 511)
+        max = 511,
+        update = ensure_universe_exists
+        )
 
     address : IntProperty(
         name = "Fixture > Address",

--- a/panels/dmx.py
+++ b/panels/dmx.py
@@ -129,8 +129,13 @@ class DMX_UL_Universe(UIList):
         ob = data
         icon = "FILE_VOLUME"
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
-            layout.prop(item, "name", text="", emboss=False, icon=icon)
-            layout.label(text=item.input)
+            col = layout.column()
+            col.label(text=f"{item.id}", icon=icon)
+            col.ui_units_x = 2
+            col = layout.column()
+            col.prop(item, "name", text="", emboss=False)
+            col = layout.column()
+            col.label(text=item.input)
         elif self.layout_type in {'GRID'}:
             layout.alignment = 'CENTER'
             layout.label(text=str(item.id), icon=icon)
@@ -267,6 +272,11 @@ class DMX_PT_DMX_ArtNet(Panel):
     def draw(self, context):
         layout = self.layout
         dmx = context.scene.dmx
+        
+        artnet_universes = []
+        for universe in dmx.universes:
+            if universe.input == "ARTNET":
+                artnet_universes.append(universe)
 
         row = layout.row()
         row.prop(dmx, "artnet_ipaddr", text="IPv4")
@@ -274,6 +284,9 @@ class DMX_PT_DMX_ArtNet(Panel):
         
         row = layout.row()
         row.prop(dmx, "artnet_enabled")
+        row.enabled = len(artnet_universes)>0
+        row = layout.row()
+        row.label(text=f"Art-Net set for {len(artnet_universes)} universe(s)")
         layout.label(text='Status: ' + layout.enum_item_name(dmx, 'artnet_status', dmx.artnet_status))
 
 class DMX_PT_DMX_sACN(Panel):
@@ -290,8 +303,18 @@ class DMX_PT_DMX_sACN(Panel):
         layout = self.layout
         dmx = context.scene.dmx
 
+        sacn_universes = []
+        for index, universe in enumerate(dmx.universes):
+            if index == 0:  # invalid for sACN
+                continue
+            if universe.input == "sACN":
+                sacn_universes.append(universe)
+
         row = layout.row()
         row.prop(dmx, "sacn_enabled")
+        row.enabled = len(sacn_universes)>0
+        row = layout.row()
+        row.label(text=f"sACN set for {len(sacn_universes)} universe(s)")
         layout.label(text='Status: ' + dmx.sacn_status)
 
 class DMX_UL_LiveDMX_items(UIList):
@@ -316,10 +339,18 @@ class DMX_PT_DMX_LiveDMX(Panel):
     def draw(self, context):
         layout = self.layout
         dmx = context.scene.dmx
+        selected_universe = dmx.get_selected_live_dmx_universe()
 
         row = layout.row()
-        row.prop(dmx, "selected_live_dmx_source", text="Source")
-        row.prop(dmx, "selected_live_dmx_universe", text="Universe")
+        row.prop(dmx, "selected_live_dmx", text="Source")
+        row = layout.row()
+        col = row.column()
+        col.label(text=f"{selected_universe.id}")
+        col.ui_units_x = 2
+        col = row.column()
+        row.label(text=f"{selected_universe.name}")
+        col = row.column()
+        row.label(text=f"{selected_universe.input}")
         layout.template_list("DMX_UL_LiveDMX_items", "", dmx, "dmx_values", dmx, "dmx_value_index", type='GRID')
 
 # Panel #

--- a/panels/dmx.py
+++ b/panels/dmx.py
@@ -131,7 +131,7 @@ class DMX_UL_Universe(UIList):
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             col = layout.column()
             col.label(text=f"{item.id}", icon=icon)
-            col.ui_units_x = 2
+            col.ui_units_x = 3
             col = layout.column()
             col.prop(item, "name", text="", emboss=False)
             col = layout.column()

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -573,27 +573,28 @@ class DMX_PT_Fixtures(Panel):
         c.label(text="Name")
         c.ui_units_x = 8 
 
-        if dmx.column_fixture_id:
+        if dmx.column_fixture_id and not dmx.fixture_properties_editable:
+
             c = row.column()
             c.label(text="F ID")
             c.ui_units_x = 2
 
-        if dmx.column_unit_number:
+        if dmx.column_unit_number and not dmx.fixture_properties_editable:
             c = row.column()
             c.ui_units_x = 2
             c.label(text="Unit #")
 
-        if dmx.column_fixture_id_numeric:
+        if dmx.column_fixture_id_numeric and not dmx.fixture_properties_editable:
             c = row.column()
             c.label(text="F ID #")
             c.ui_units_x = 2
 
-        if dmx.column_custom_id:
+        if dmx.column_custom_id and not dmx.fixture_properties_editable:
             c = row.column()
             c.label(text="Cst ID")
             c.ui_units_x = 2
 
-        if dmx.column_dmx_address:
+        if dmx.column_dmx_address and not dmx.fixture_properties_editable:
             c = row.column()
             c.ui_units_x = 2
             if dmx.fixture_properties_editable:
@@ -604,11 +605,6 @@ class DMX_PT_Fixtures(Panel):
             else:
                 c.label(text="Uni.Addr")
     
-        if dmx.fixture_properties_editable:
-            c = row.column()
-            c.ui_units_x = 2
-            c.label(text="Del")
-
         layout.template_list(
             "DMX_UL_Fixtures",
             "",
@@ -730,6 +726,23 @@ class DMX_UL_Fixtures(UIList):
             else:
                 c.label(text=f"{item.universe}.{item.address}")
     
+        if dmx.fixture_properties_editable:
+            body = None
+            for obj in item.collection.objects:
+                if obj.get("geometry_root", False):
+                    body = obj
+                    break
+            if body is not None:
+                col = layout.column()
+                col.prop(body, "location", index=0, text='')
+                col.ui_units_x = 3
+                col = layout.column()
+                col.ui_units_x = 3
+                col.prop(body, "location", index=1, text='')
+                col = layout.column()
+                col.prop(body, "location", index=2, text='')
+                col.ui_units_x = 3
+
         if dmx.fixture_properties_editable:
             col = layout.column()
             col.context_pointer_set("fixture", item)

--- a/universe.py
+++ b/universe.py
@@ -29,7 +29,7 @@ class DMX_Universe(PropertyGroup):
     name: StringProperty (
         name = "Name",
         description = "Name of the universe",
-        default = "DMX 0"
+        default = "Universe 0"
     )
 
     input: EnumProperty (


### PR DESCRIPTION
- rename default universe name from "DMX" to "Universe"
- allow to enable Art-Net/sACN only if at least one universe is set to these sources. 
- allow to choose a Live DMX view only to universes which are preset, rather then an arbitrary protocol/universe combination
- ensure universe exists also when editing fixture universe in the new fixture view