### PR TITLE
WIP: Initial gobo support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -993,7 +993,6 @@ class DMX(PropertyGroup):
                 continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
-                    deg =self.programmer_zoom
                     fixture.setDMX({
                         'Zoom':int(self.programmer_zoom)
                     })
@@ -1098,7 +1097,6 @@ class DMX(PropertyGroup):
         active = self.findFixture(bpy.context.active_object)
         if (not active): return
         data = active.getProgrammerData()
-        print("data", data)
         if 'Dimmer' in data:
             self.programmer_dimmer = data['Dimmer']/256.0
         if 'Shutter1' in data:

--- a/__init__.py
+++ b/__init__.py
@@ -147,7 +147,6 @@ class DMX(PropertyGroup):
                 DMX_PT_Setup_Background,
                 DMX_PT_Setup_Volume,
                 DMX_PT_Setup_Debug,
-                DMX_PT_Setup_Experimental,
                 DMX_MT_Fixture,
                 DMX_MT_Fixture_Manufacturers,
                 DMX_MT_Fixture_Profiles,
@@ -335,11 +334,6 @@ class DMX(PropertyGroup):
 
     fixture_properties_editable: BoolProperty(
         name = "Editable",
-        default = False)
-    
-    gobo_support: BoolProperty(
-        name = "Gobo support",
-        description = "Crashes Cycles",
         default = False)
 
     # New DMX Scene
@@ -999,12 +993,41 @@ class DMX(PropertyGroup):
                 continue
             for obj in fixture.collection.objects:
                 if (obj in bpy.context.selected_objects):
-                    print("set zoom", self.programmer_zoom)
                     deg =self.programmer_zoom
-                    print("deg", deg)
-                    print("size", 2* 1 * math.tan(math.radians(deg/2)))
                     fixture.setDMX({
                         'Zoom':int(self.programmer_zoom)
+                    })
+        self.render()
+        bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
+    
+    def onProgrammerGobo(self, context):
+        bpy.app.handlers.depsgraph_update_post.clear()
+        for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
+            for obj in fixture.collection.objects:
+                if (obj in bpy.context.selected_objects):
+                    fixture.setDMX({
+                        'Gobo1':int(self.programmer_gobo)
+                    })
+                    fixture.setDMX({
+                        'Gobo2':int(self.programmer_gobo)
+                    })
+        self.render()
+        bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
+
+    def onProgrammerGoboIndex(self, context):
+        bpy.app.handlers.depsgraph_update_post.clear()
+        for fixture in self.fixtures:
+            if fixture.collection is None:
+                continue
+            for obj in fixture.collection.objects:
+                if (obj in bpy.context.selected_objects):
+                    fixture.setDMX({
+                        'Gobo1Pos':int(self.programmer_gobo_index)
+                    })
+                    fixture.setDMX({
+                        'Gobo2Pos':int(self.programmer_gobo_index)
                     })
         self.render()
         bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
@@ -1036,6 +1059,20 @@ class DMX(PropertyGroup):
         default = 25,
         update = onProgrammerZoom)
 
+    programmer_gobo: IntProperty(
+        name = "Programmer Gobo",
+        min = 0,
+        max = 255,
+        default = 0,
+        update = onProgrammerGobo)
+
+    programmer_gobo_index: IntProperty(
+        name = "Programmer Gobo Index",
+        min = 0,
+        max = 255,
+        default = 63,
+        update = onProgrammerGoboIndex)
+
     programmer_shutter: IntProperty(
         name = "Programmer Shutter",
         min = 0,
@@ -1045,7 +1082,6 @@ class DMX(PropertyGroup):
     # # Programmer > Sync
 
     def syncProgrammer(self):
-        print("sync prog")
         n = len(bpy.context.selected_objects)
         if (n < 1):
             self.programmer_dimmer = 0
@@ -1054,6 +1090,8 @@ class DMX(PropertyGroup):
             self.programmer_tilt = 0
             self.programmer_zoom = 25
             self.programmer_shutter = 0
+            self.programmer_gobo = 0
+            self.programmer_gobo_index = 63
             return
         elif (n > 1): return
         if (not bpy.context.active_object): return
@@ -1067,6 +1105,14 @@ class DMX(PropertyGroup):
             self.programmer_shutter = int(data['Shutter1']/256.0)
         if ('Zoom' in data):
             self.programmer_zoom = int(data['Zoom'])
+        if ('Gobo1' in data):
+            self.programmer_gobo = int(data['Gobo1'])
+        if ('Gobo2' in data):
+            self.programmer_gobo = int(data['Gobo2'])
+        if ('Gobo1Pos' in data):
+            self.programmer_gobo_index = int(data['Gobo1Pos'])
+        if ('Gobo2Pos' in data):
+            self.programmer_gobo_index = int(data['Gobo2Pos'])
         if ('ColorAdd_R' in data and 'ColorAdd_G' in data and 'ColorAdd_B' in data):
             self.programmer_color = (data['ColorAdd_R'],data['ColorAdd_G'],data['ColorAdd_B'],255)
         if ('Pan' in data):

--- a/fixture.py
+++ b/fixture.py
@@ -459,13 +459,14 @@ class DMX_Fixture(PropertyGroup):
         channels = [c.id for c in self.channels]
         data = DMX_Data.get(self.universe, self.address, len(channels))
 
-        s_data = json.dumps([int(b) for b in data]) # create cache, this maybe is not fast enough
-        if self.dmx_values == s_data: # this helps to eliminate flicker with Ethernet DMX signal when the data is not changing
-                return
-        self.dmx_values  = s_data
-
         data_virtual = DMX_Data.get_virtual(self.name)
         virtual_channels = [c.id for c in self.virtual_channels]
+
+        s_data = json.dumps([int(b) for b in data] + [int(b) for b in data_virtual.values()]) # create cache, this maybe is not fast enough
+        if self.dmx_values == s_data: # this helps to eliminate flicker with Ethernet DMX signal when the data is not changing
+            return
+        self.dmx_values  = s_data
+
         panTilt = [None,None, 1, 1] # pan, tilt, 1 = 8bit, 256 = 16bit
         cmy = [None,None,None]
         zoom = None

--- a/material.py
+++ b/material.py
@@ -74,21 +74,26 @@ def getVolumeScatterMaterial():
 
 
 def get_gobo_material(name):
+    """Material for gobo projection.
+    The commented out lines have originally been used
+    but there doesn't seem to be difference without them
+    keeping them here just in case."""
+
     if name in bpy.data.materials:
         bpy.data.materials.remove(bpy.data.materials[name])
     material = bpy.data.materials.new(name)
     material.use_nodes = True
     material.node_tree.nodes.remove(material.node_tree.nodes[PRINCIPLED_BSDF])
     matout = material.node_tree.nodes.get(MATERIAL_OUTPUT)
-    #matout.target = "EEVEE"
-    #mix = material.node_tree.nodes.new(SHADER_NODE_MIX_SHADER)
-    #mix.inputs[0].default_value = 0.010
-    #material.node_tree.links.new(matout.inputs[0], mix.outputs[0])
+    # matout.target = "EEVEE"
+    # mix = material.node_tree.nodes.new(SHADER_NODE_MIX_SHADER)
+    # mix.inputs[0].default_value = 0.010
+    # material.node_tree.links.new(matout.inputs[0], mix.outputs[0])
     bsdf = material.node_tree.nodes.new(SHADER_NODE_BSDF_TRANSPARENT)
-    #material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
+    # material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
     material.node_tree.links.new(matout.inputs[0], bsdf.outputs[0])
     image = material.node_tree.nodes.new(SHADER_NODE_TEX_IMAGE)
-    #material.node_tree.links.new(image.outputs[1], mix.inputs[2])
+    # material.node_tree.links.new(image.outputs[1], mix.inputs[2])
     material.node_tree.links.new(image.outputs[0], bsdf.inputs[0])
-    #material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
+    # material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
     return material

--- a/material.py
+++ b/material.py
@@ -80,14 +80,15 @@ def get_gobo_material(name):
     material.use_nodes = True
     material.node_tree.nodes.remove(material.node_tree.nodes[PRINCIPLED_BSDF])
     matout = material.node_tree.nodes.get(MATERIAL_OUTPUT)
-    matout.target = "EEVEE"
-    mix = material.node_tree.nodes.new(SHADER_NODE_MIX_SHADER)
-    mix.inputs[0].default_value = 0.010
-    material.node_tree.links.new(matout.inputs[0], mix.outputs[0])
+    #matout.target = "EEVEE"
+    #mix = material.node_tree.nodes.new(SHADER_NODE_MIX_SHADER)
+    #mix.inputs[0].default_value = 0.010
+    #material.node_tree.links.new(matout.inputs[0], mix.outputs[0])
     bsdf = material.node_tree.nodes.new(SHADER_NODE_BSDF_TRANSPARENT)
-    material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
+    #material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
+    material.node_tree.links.new(matout.inputs[0], bsdf.outputs[0])
     image = material.node_tree.nodes.new(SHADER_NODE_TEX_IMAGE)
-    material.node_tree.links.new(image.outputs[1], mix.inputs[2])
+    #material.node_tree.links.new(image.outputs[1], mix.inputs[2])
     material.node_tree.links.new(image.outputs[0], bsdf.inputs[0])
-    material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
+    #material.node_tree.links.new(bsdf.outputs[0], mix.inputs[1])
     return material

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -487,9 +487,6 @@ class DMX_OT_Fixture_SelectPrevious(Operator):
         selected_all = dmx.selectedFixtures()
         fixtures = dmx.sortedFixtures()
 
-        if not selected_all and fixtures:
-            selected_all = [fixtures[-1]] # if nothing is selected, select last
-
         for fixture in fixtures:
             fixture.unselect()
 
@@ -501,6 +498,10 @@ class DMX_OT_Fixture_SelectPrevious(Operator):
                         idx = len(fixtures)-1
                     fixtures[idx].select()
                     break
+
+        if not selected_all and fixtures:
+            fixtures[-1].select()
+
         return {'FINISHED'}
 
 class DMX_OT_Fixture_SelectNext(Operator):
@@ -515,9 +516,6 @@ class DMX_OT_Fixture_SelectNext(Operator):
         selected_all = dmx.selectedFixtures()
         fixtures = dmx.sortedFixtures()
 
-        if not selected_all and fixtures:
-            selected_all = [fixtures[0]] # if nothing is selected, select first
-
         for fixture in fixtures:
             fixture.unselect()
 
@@ -529,6 +527,10 @@ class DMX_OT_Fixture_SelectNext(Operator):
                         idx = 0
                     fixtures[idx].select()
                     break
+
+        if not selected_all and fixtures:
+            fixtures[0].select()
+
         return {'FINISHED'}
 
 class DMX_OT_Fixture_Item(Operator):

--- a/panels/programmer.py
+++ b/panels/programmer.py
@@ -259,6 +259,14 @@ class DMX_PT_Programmer(Panel):
 
         selected = len(selected_fixtures) > 0
 
+        selected_fixture_label = ""
+        if len(selected_fixtures) == 0:
+            selected_fixture_label = "Nothing selected"
+        elif len(selected_fixtures) == 1:
+            selected_fixture_label = selected_fixtures[0].name
+        else:
+            selected_fixture_label = f"{len(selected_fixtures)} selected"
+
         row = layout.row()
         row.operator("dmx.select_all", text='', icon='SELECT_EXTEND')
         row.operator("dmx.select_invert", text='', icon='SELECT_SUBTRACT')
@@ -276,6 +284,8 @@ class DMX_PT_Programmer(Panel):
         c1.enabled = c2.enabled = c3.enabled = selected
         c4.enabled = locked and selected
 
+        row = layout.row()
+        row.label(text=selected_fixture_label)
         row = layout.row()
         row.operator("dmx.select_bodies", text="Bodies")
         row.operator("dmx.select_targets", text="Targets")

--- a/panels/programmer.py
+++ b/panels/programmer.py
@@ -151,7 +151,9 @@ class DMX_OT_Programmer_Clear(Operator):
         scene.dmx.programmer_dimmer = 0.0
         scene.dmx.programmer_pan = 0.0
         scene.dmx.programmer_tilt = 0.0
-        scene.dmx.programmer_zoom = 0
+        scene.dmx.programmer_zoom = 25
+        scene.dmx.programmer_gobo = 0
+        scene.dmx.programmer_gobo_index = 63
         scene.dmx.programmer_shutter = 0
         return {'FINISHED'}
 
@@ -247,14 +249,15 @@ class DMX_PT_Programmer(Panel):
         dmx = scene.dmx
 
         locked = False
-
+        selected_fixtures = []
         for fixture in dmx.fixtures:
             for obj in fixture.collection.objects:
                 if obj in bpy.context.selected_objects:
+                    selected_fixtures.append(fixture)
                     if fixture.ignore_movement_dmx is True:
                         locked = True
 
-        selected = len(bpy.context.selected_objects) > 0
+        selected = len(selected_fixtures) > 0
 
         row = layout.row()
         row.operator("dmx.select_all", text='', icon='SELECT_EXTEND')
@@ -276,24 +279,35 @@ class DMX_PT_Programmer(Panel):
         row = layout.row()
         row.operator("dmx.select_bodies", text="Bodies")
         row.operator("dmx.select_targets", text="Targets")
-        if len(bpy.context.selected_objects) == 1:
-            for fixture in dmx.fixtures:
-                for obj in fixture.collection.objects:
-                    if (obj in bpy.context.selected_objects):
-                        for obj in fixture.collection.objects:
-                            if "MediaCamera" in obj.name:
-                                row.operator("dmx.toggle_camera", text="Camera")
+        if len(selected_fixtures) == 1:
+            for obj in selected_fixtures[0].collection.objects:
+                if "MediaCamera" in obj.name:
+                    row.operator("dmx.toggle_camera", text="Camera")
         row.enabled = selected
 
         layout.template_color_picker(scene.dmx,"programmer_color", value_slider=True)
         layout.prop(scene.dmx, "programmer_color")
         layout.prop(scene.dmx,"programmer_dimmer", text="Dimmer")
-
-        layout.prop(scene.dmx,"programmer_pan", text="Pan")
-        layout.prop(scene.dmx,"programmer_tilt", text="Tilt")
-
-        layout.prop(scene.dmx,"programmer_zoom", text="Zoom")
-        layout.prop(scene.dmx,"programmer_shutter", text="Strobe")
+        
+        if len(selected_fixtures) == 1:
+            if selected_fixtures[0].has_attribute("Pan"):
+                layout.prop(scene.dmx,"programmer_pan", text="Pan")
+            if selected_fixtures[0].has_attribute("Tilt"):
+                layout.prop(scene.dmx,"programmer_tilt", text="Tilt")
+            if selected_fixtures[0].has_attribute("Zoom"):
+                layout.prop(scene.dmx,"programmer_zoom", text="Zoom")
+            if selected_fixtures[0].has_attribute("Gobo"):
+                layout.prop(scene.dmx,"programmer_gobo", text="Gobo")
+                layout.prop(scene.dmx,"programmer_gobo_index", text="GoboPos")
+            if selected_fixtures[0].has_attribute("shutter", lower = True):
+                layout.prop(scene.dmx,"programmer_shutter", text="Strobe")
+        else:
+            layout.prop(scene.dmx,"programmer_pan", text="Pan")
+            layout.prop(scene.dmx,"programmer_tilt", text="Tilt")
+            layout.prop(scene.dmx,"programmer_zoom", text="Zoom")
+            layout.prop(scene.dmx,"programmer_gobo", text="Gobo")
+            layout.prop(scene.dmx,"programmer_gobo_index", text="GoboPos")
+            layout.prop(scene.dmx,"programmer_shutter", text="Strobe")
 
         if (selected):
             layout.operator("dmx.clear", text="Clear")

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -142,22 +142,6 @@ class DMX_PT_Setup_Debug(Panel):
         row = layout.row()
         row.label(text = f"Status: {context.window_manager.dmx.release_version_status}")
 
-class DMX_PT_Setup_Experimental(Panel):
-    bl_label = "Experimental"
-    bl_idname = "DMX_PT_Setup_Experimental"
-    bl_parent_id = "DMX_PT_Setup"
-    bl_space_type = "VIEW_3D"
-    bl_region_type = "UI"
-    bl_category = "DMX"
-    bl_context = "objectmode"
-    bl_options = {'DEFAULT_CLOSED'}
-
-    def draw(self, context):
-        layout = self.layout
-        dmx = context.scene.dmx
-        row = layout.row()
-        row.prop(dmx, 'gobo_support')
-
 # Panel #
 
 class DMX_PT_Setup(Panel):

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -142,6 +142,22 @@ class DMX_PT_Setup_Debug(Panel):
         row = layout.row()
         row.label(text = f"Status: {context.window_manager.dmx.release_version_status}")
 
+class DMX_PT_Setup_Experimental(Panel):
+    bl_label = "Experimental"
+    bl_idname = "DMX_PT_Setup_Experimental"
+    bl_parent_id = "DMX_PT_Setup"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "DMX"
+    bl_context = "objectmode"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        dmx = context.scene.dmx
+        row = layout.row()
+        row.prop(dmx, 'gobo_support')
+
 # Panel #
 
 class DMX_PT_Setup(Panel):
@@ -183,8 +199,9 @@ class DMX_OT_VersionCheck(Operator):
                 elif res > 0:
                     text = "You are using pre-release version"
                 else:
-                    text = "You are using latest version"
+                    text = "You are using latest version of BlenderDMX"
 
+        self.report({"INFO"}, f"{text}")
         temp_data.release_version_status = text
 
     def execute(self, context):


### PR DESCRIPTION
- initial support for gobos
- loads gobo images from GDTF
- gobo selection, indexing and rotation
- crashes Blender 3.6 in Cycles but works correctly in Blender 4.x

[gobo_wip.webm](https://github.com/open-stage/blender-dmx/assets/3680926/eafb2495-97a4-4793-9f09-82be2bd81243)
