### PR TITLE
Support gobo keyframing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -354,7 +354,7 @@ class DMX(PropertyGroup):
 
     data_version: IntProperty(
             name = "BlenderDMX data version, bump when changing RNA structure and provide migration script",
-            default = 5,
+            default = 6,
             )
 
     def get_fixture_by_index(self, index):
@@ -627,6 +627,9 @@ class DMX(PropertyGroup):
                     DMX_Log.log.info("Adding dmx_value array to fixture")
                     fixture["dmx_values"] = []
 
+        if file_data_version < 6:
+            DMX_Log.log.info("Running migration 5→6")
+            DMX_Log.log.info("To make gobos working again, edit fixtures with gobos - re-load GDTF files (Fixtures → Edit, uncheck Re-address only)")
 
         DMX_Log.log.info("Migration done.")
         self.logging_level = "ERROR"

--- a/__init__.py
+++ b/__init__.py
@@ -213,7 +213,10 @@ class DMX(PropertyGroup):
                 DMX_OT_VersionCheck,
                 DMX_PT_Programmer,
                 DMX_OT_Recorder_AddKeyframe,
-                DMX_PT_Recorder  )
+                DMX_PT_Recorder,
+                DMX_PT_DMX_Recorder_Delete,
+                DMX_OT_Recorder_Delete_Keyframes_Selected,
+                DMX_OT_Recorder_Delete_Keyframes_All)
 
     linkedToFile = False
     _keymaps = []
@@ -1156,6 +1159,7 @@ class DMX(PropertyGroup):
         max = 255,
         default = 0,
         update = onProgrammerShutter)
+
     # # Programmer > Sync
 
     def syncProgrammer(self):
@@ -1522,7 +1526,7 @@ class DMX(PropertyGroup):
             #make the frame the same for all fixtures
             current_frame = bpy.data.scenes[0].frame_current
         else:
-            current_frame = -1
+            current_frame = None
 
         for fixture in self.fixtures:
             fixture.render(current_frame=current_frame)

--- a/panels/recorder.py
+++ b/panels/recorder.py
@@ -8,41 +8,133 @@
 
 import bpy
 
-from bpy.types import (Panel,
-                       Operator)
+from bpy.types import Panel, Operator
 from dmx.logging import DMX_Log
+
 
 class DMX_OT_Recorder_AddKeyframe(Operator):
     bl_label = "DMX > Recorder > Add Keyframe"
     bl_idname = "dmx.recorder_add_keyframe"
     bl_description = "Add a Keyframe with the current DMX data"
-    bl_options = {'UNDO'}
+    bl_options = {"UNDO"}
 
     def execute(self, context):
-        #DMX_Recorder.add_keyframe()
+        # DMX_Recorder.add_keyframe()
         dmx = bpy.context.scene.dmx
         DMX_Log.log.debug("run add frame")
 
-        #make the frame the same for all fixtures
+        # make the frame the same for all fixtures
         current_frame = bpy.data.scenes[0].frame_current
-
         for fixture in dmx.fixtures:
             fixture.render(skip_cache=True, current_frame=current_frame)
             DMX_Log.log.debug(f"keyframe fixture {fixture.name}")
-        return {'FINISHED'}
+        return {"FINISHED"}
+
+
+def clear_animation_data(fixture):
+    DMX_Log.log.debug(f"clear animation data of a fixture: {fixture.name}")
+    for obj in fixture.collection.objects:
+        if obj.animation_data:
+            obj.animation_data.action = None
+            obj.animation_data_clear()
+
+    for emitter_material in fixture.emitter_materials:
+        etree = emitter_material.material.node_tree
+
+        if etree.animation_data:
+            etree.animation_data.action = None
+            etree.animation_data_clear()
+
+    for light in fixture.lights:
+        ld = light.object.data
+
+        if ld.animation_data:
+            ld.animation_data.action = None
+            ld.animation_data_clear()
+
+
+class DMX_OT_Recorder_Delete_Keyframes_All(Operator):
+    bl_label = "DMX > Recorder > Delete Keyframes for all fixtures"
+    bl_idname = "dmx.recorder_delete_keyframes_all"
+    bl_description = "Deletes all keyframes from all fixtures"
+    bl_options = {"UNDO"}
+
+    def execute(self, context):
+        dmx = context.scene.dmx
+
+        for fixture in dmx.fixtures:
+            clear_animation_data(fixture)
+
+        return {"FINISHED"}
+
+
+class DMX_OT_Recorder_Delete_Keyframes_Selected(Operator):
+    bl_label = "DMX > Recorder > Delete All Keyframes from selected fixtures"
+    bl_idname = "dmx.recorder_delete_keyframes_selected"
+    bl_description = "Deletes all keyframes from selected fixtures"
+    bl_options = {"UNDO"}
+
+    def execute(self, context):
+        dmx = context.scene.dmx
+
+        selected = []
+        for fixture in dmx.fixtures:
+            for obj in fixture.collection.objects:
+                if obj in bpy.context.selected_objects:
+                    selected.append(fixture)
+
+        for fixture in dmx.fixtures:
+            if fixture in selected:
+                clear_animation_data(fixture)
+
+        return {"FINISHED"}
+
 
 # Panels #
 
+
 class DMX_PT_Recorder(Panel):
-    bl_label = "Recorder"
+    bl_label = "Keyframe Recorder"
     bl_idname = "DMX_PT_Recorder"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "DMX"
     bl_context = "objectmode"
+    bl_options = {"DEFAULT_CLOSED"}
 
     def draw(self, context):
         layout = self.layout
         scene = context.scene
-        layout.operator("dmx.recorder_add_keyframe", text='Add Keyframe', icon='PLUS')
+        layout.operator("dmx.recorder_add_keyframe", text="Add Keyframe", icon="PLUS")
         layout.prop(scene.tool_settings, "use_keyframe_insert_auto")
+
+
+class DMX_PT_DMX_Recorder_Delete(Panel):
+    bl_label = "Delete Keyframes"
+    bl_idname = "DMX_PT_DMX_Recorder_Delete"
+    bl_parent_id = "DMX_PT_Recorder"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "DMX"
+    bl_context = "objectmode"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context):
+        layout = self.layout
+        dmx = context.scene.dmx
+        selected_fixtures = []
+        for fixture in dmx.fixtures:
+            for obj in fixture.collection.objects:
+                if obj in bpy.context.selected_objects:
+                    selected_fixtures.append(fixture)
+
+        selected = len(selected_fixtures) > 0
+        fixtures_exist = len(dmx.fixtures) > 0
+
+        row = layout.row()
+        row.operator("dmx.recorder_delete_keyframes_selected", text="Delete from selected fixtures", icon="SELECT_DIFFERENCE")
+        row.enabled = selected
+
+        row = layout.row()
+        row.operator("dmx.recorder_delete_keyframes_all", text="Delete from all fixtures", icon="SELECT_EXTEND")
+        row.enabled = fixtures_exist


### PR DESCRIPTION
- Add support to keyframe gobos
- Handle hiding of gobo geometry
- Loading of gobos had to be redone to load images as Blender image sequence. Previous blender files can be updated by editing GDTF fixtures - reloading the GDTF files