### PR TITLE
Add support for Gobos in Cycles

### DIFF
--- a/mvr.py
+++ b/mvr.py
@@ -251,6 +251,7 @@ def getCollectionName(string):
 def loadModelAndPrepareMvrFileCollection(file, folder):
     object_collection = bpy.data.collections.new(getCollectionName(file))
     file_name = os.path.join(folder, file)
+    DMX_Log.log.debug(f"filename to be loaded {file_name}")
     file_3ds = False
     if file_name.split(".")[-1] == "glb":
         bpy.ops.import_scene.gltf(filepath=file_name)
@@ -288,7 +289,11 @@ def add_mvr_object(
     if cached_collection_name in bpy.data.collections:
         mvr_file_collection = bpy.data.collections[cached_collection_name]
     else:
-        mvr_file_collection = loadModelAndPrepareMvrFileCollection(file, folder)
+        file_name = os.path.join(folder, file)
+        if os.path.isfile(file_name):
+            mvr_file_collection = loadModelAndPrepareMvrFileCollection(file, folder)
+        else:
+            return
 
     collection_name = name
     object_collection = bpy.data.collections.new(collection_name)

--- a/panels/recorder.py
+++ b/panels/recorder.py
@@ -52,6 +52,11 @@ def clear_animation_data(fixture):
             ld.animation_data.action = None
             ld.animation_data_clear()
 
+        ld_tree = ld.node_tree
+        if ld_tree.animation_data:
+            ld_tree.animation_data.action = None
+            ld_tree.animation_data_clear()
+
 
 class DMX_OT_Recorder_Delete_Keyframes_All(Operator):
     bl_label = "DMX > Recorder > Delete Keyframes for all fixtures"


### PR DESCRIPTION
- add support for Gobos in Cycles, including rotation and setting to clean beam when gobo == 0
- ensure keyframing works
- ensure delete keyframes removes deeper node_tree animations in lights
- handle possible missing file in MVR import