### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Changelog
 
+### 1.3.0
+
+    * Add support for gobos in Cycles
+    * Add translation of UI
+    * Add Noise Scatter to Volume box
+    * Enable programmer only if any fixture is selected
+    * Small improvements:
+        * GDTF download: Better sanitizing of GDTF download file name
+        * Handle ArtNet status setting error
+        * MVR import: check if file exists before loading it
+        * Handle fixtures without dimmer
+        * Handle fixtures with gobo but without zoom
+
 ### 1.2.0
 
     * Initial keyframing support with Auto Keying and Manual Keyframe insert

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A DMX visualization tool inside <a href="https://blender.org">Blender</a>, desig
 
 First of all, make sure you have installed [Blender 3.4](https://www.blender.org/download/) or higher (Blender 4.x is supported). Then, download the `zip` file:
 
-### LATEST RELEASE (STABLE): v1.2.0
+### LATEST RELEASE (STABLE): v1.3.0
 
-   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.2.0.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.2.0/blenderDMX_v1.2.0.zip) file
+   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.3.0.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.3.0/blenderDMX_v1.3.0.zip) file
 
 ### ROLLING RELEASE (UNSTABLE)
 

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 2, 0),
+    "version": (1, 3, 0),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",

--- a/fixture.py
+++ b/fixture.py
@@ -488,7 +488,7 @@ class DMX_Fixture(PropertyGroup):
         rgb_mixing_geometries={}
         xyz_moving_geometries={}
         xyz_rotating_geometries={}
-        shutter_dimmer_geometries={}
+        shutter_dimmer_geometries={} # item: shutter, dimmer, unused, dimmer bits
         gobo1 = [None, None] #gobo selection (Gobo1, Gobo2), gobo indexing/rotation (Gobo1Pos, Gobo2Pos)
 
         for attribute in virtual_channels:
@@ -614,6 +614,8 @@ class DMX_Fixture(PropertyGroup):
             if shutter_dimmer[0] is not None or shutter_dimmer[1] is not None:
                 if shutter_dimmer[0] is None:
                     shutter_dimmer[0] = 0 # if device doesn't have shutter, set default value
+                if shutter_dimmer[1] is None:
+                    shutter_dimmer[1] = 100 # if device doesn't have dimmer, set default value
                 self.updateShutterDimmer(shutter_dimmer[0], shutter_dimmer[1], geometry, shutter_dimmer[3], current_frame)
 
     def remove_unset_geometries_from_multigeometry_attributes(self, dictionary):

--- a/gdtf.py
+++ b/gdtf.py
@@ -421,8 +421,9 @@ class DMX_GDTF():
             constraint.target = obj_child
             collection.objects.link(light_object)
 
+            gobo_radius = 2.2 * 0.01 * math.tan(math.radians(geometry.beam_angle/2))
             goboGeometry = SimpleNamespace(name=f"gobo {sanitize_obj_name(geometry)}",
-                                           length=0.1, width=0.1, height = 0, primitive_type = "Plane",
+                                           length=gobo_radius, width=gobo_radius, height = 0, primitive_type = "Plane",
                                            beam_radius = geometry.beam_radius)
             create_gobo(geometry, goboGeometry)
 


### PR DESCRIPTION
### 1.3.0

* Add support for gobos in Cycles
* Add translation of UI
* Add Noise Scatter to Volume box
* Enable programmer only if any fixture is selected
    * Small improvements:
        * GDTF download: Better sanitizing of GDTF download file name
        * Handle ArtNet status setting error
        * MVR import: check if file exists before loading it
        * Handle fixtures without dimmer
        * Handle fixtures with gobo but without zoom
