### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Changelog
 
+### 1.3.1
+
+    * Add support to import IES photometrics and apply them to beams in Cycles
+    * Allow changing beam lens diameter for Cycles, based on global or per fixture settings
+    * Set hidden objects as hidden also for renderer
+    * Make more items translatable, disable automatic translation for Fixture controls
+    * Add version checks on start for Python, Blender, and for the BlenderDMX addon
+
 ### 1.3.0
 
     * Add support for gobos in Cycles

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A DMX visualization tool inside <a href="https://blender.org">Blender</a>, desig
 
 First of all, make sure you have installed [Blender 3.4](https://www.blender.org/download/) or higher (Blender 4.x is supported). Then, download the `zip` file:
 
-### LATEST RELEASE (STABLE): v1.3.0
+### LATEST RELEASE (STABLE): v1.3.1
 
-   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.3.0.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.3.0/blenderDMX_v1.3.0.zip) file
+   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.3.1.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.3.1/blenderDMX_v1.3.1.zip) file
 
 ### ROLLING RELEASE (UNSTABLE)
 

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 3, 0),
+    "version": (1, 3, 1),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",


### PR DESCRIPTION
* Add support to import IES photometrics and apply them to beams in Cycles
* Allow changing beam lens diameter for Cycles, based on global or per fixture settings
* Set hidden objects as hidden also for renderer
* Make more items translatable, disable automatic translation for Fixture controls
* Add version checks on start for Python, Blender, and for the BlenderDMX addon
