### PR TITLE
Improvements to pan/tilt handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1639,7 +1639,7 @@ def onDepsgraph(scene):
         for fixture in scene.dmx.fixtures:
             for f_obj in fixture.objects:
                 if (obj.name == f_obj.object.name):
-                    fixture.onDepsgraphUpdate()
+                    fixture.onDepsgraphUpdate(depsgraph.updates)
                     found = True
                     break
             if found: break

--- a/__init__.py
+++ b/__init__.py
@@ -216,6 +216,8 @@ class DMX(PropertyGroup):
                 DMX_OT_Fixture_ForceRemove,
                 DMX_OT_Fixture_SelectNext,
                 DMX_OT_Fixture_SelectPrevious,
+                DMX_OT_Fixture_SelectNextTarget,
+                DMX_OT_Fixture_SelectPreviousTarget,
                 DMX_OT_VersionCheck,
                 DMX_PT_Programmer,
                 DMX_OT_Recorder_AddKeyframe,
@@ -246,11 +248,14 @@ class DMX(PropertyGroup):
         # register key shortcuts
         wm = bpy.context.window_manager
         km = wm.keyconfigs.addon.keymaps.new(name='3D View Generic', space_type='VIEW_3D')
-        kmi = km.keymap_items.new('dmx.fixture_next', 'RIGHT_ARROW', 'PRESS', ctrl=True)
+        kmi = km.keymap_items.new('dmx.fixture_next', 'RIGHT_ARROW', 'PRESS', ctrl=True, shift=False)
         DMX._keymaps.append((km, kmi))
-        kmi = km.keymap_items.new('dmx.fixture_previous', 'LEFT_ARROW', 'PRESS', ctrl=True)
+        kmi = km.keymap_items.new('dmx.fixture_previous', 'LEFT_ARROW', 'PRESS', ctrl=True, shift=False)
         DMX._keymaps.append((km, kmi))
-
+        kmi = km.keymap_items.new('dmx.fixture_next_target', 'RIGHT_ARROW', 'PRESS', ctrl=True, shift=True)
+        DMX._keymaps.append((km, kmi))
+        kmi = km.keymap_items.new('dmx.fixture_previous_target', 'LEFT_ARROW', 'PRESS', ctrl=True, shift=True)
+        DMX._keymaps.append((km, kmi))
 
     def unregister():
         # unregister keymaps

--- a/fixture.py
+++ b/fixture.py
@@ -911,7 +911,15 @@ class DMX_Fixture(PropertyGroup):
 
     def updatePanTilt(self, pan, tilt, pan_bits, tilt_bits, current_frame):
         if self.ignore_movement_dmx:
+            # programming by target, dmx for p/t locked
+            if "Target" in self.objects:
+                target = self.objects['Target'].object
+                if current_frame:
+                    target.keyframe_insert(data_path="location", frame=current_frame)
+                    target.keyframe_insert(data_path="rotation_euler", frame=current_frame)
             return
+
+
         DMX_Log.log.info("Updating pan tilt")
         pan = (pan/(pan_bits*127.0)-1)*540*(math.pi/360)
         tilt = (tilt/(tilt_bits*127.0)-1)*270*(math.pi/360)

--- a/fixture.py
+++ b/fixture.py
@@ -1000,14 +1000,18 @@ class DMX_Fixture(PropertyGroup):
             params[channels[c]] = data[c]
         return params
 
-    def select(self):
+
+    def select(self, select_target = False):
         dmx = bpy.context.scene.dmx
         if dmx.display_2D:
             # in 2D view deselect the 2D symbol, unhide the fixture and select base,
             # to allow movement and rotation
             self.objects["2D Symbol"].object.select_set(False)
+            targets = []
 
             for obj in self.collection.objects:
+                if ('Target' in self.objects):
+                    targets.append(self.objects['Target'].object)
                 if "pigtail" in obj.get("geometry_type", ""):
                     obj.hide_set(not bpy.context.scene.dmx.display_pigtails)
                     obj.hide_viewport = not bpy.context.scene.dmx.display_pigtails
@@ -1018,12 +1022,28 @@ class DMX_Fixture(PropertyGroup):
                 obj.hide_viewport = False
                 obj.hide_render = False
 
-            if "Root" in self.objects:
-                self.objects["Root"].object.select_set(True)
+            if not select_target:
+                if "Root" in self.objects:
+                    self.objects["Root"].object.select_set(True)
+            else:
+                if (len(targets)):
+                    for target in targets:
+                        target.select_set(True)
 
         else:
-            if "Root" in self.objects:
-                self.objects["Root"].object.select_set(True)
+
+            if not select_target:
+                if "Root" in self.objects:
+                    self.objects["Root"].object.select_set(True)
+            else:
+                targets = []
+                for obj in self.collection.objects:
+                    if ('Target' in self.objects):
+                        targets.append(self.objects['Target'].object)
+
+                if (len(targets)):
+                    for target in targets:
+                        target.select_set(True)
 
         DMX_OSC_Handlers.fixture_selection(self)
         dmx.updatePreviewVolume()

--- a/panels/fixtures.py
+++ b/panels/fixtures.py
@@ -550,6 +550,51 @@ class DMX_OT_Fixture_Import_MVR(Operator):
 
 # Panel #
 
+
+def select_previous(context, select_target = False):
+    scene = context.scene
+    dmx = scene.dmx
+    selected_all = dmx.selectedFixtures()
+    fixtures = dmx.sortedFixtures()
+
+    for fixture in fixtures:
+        fixture.unselect()
+
+    for selected in selected_all:
+        for idx, fixture in enumerate(fixtures):
+            if fixture == selected:
+                idx -= 1
+                if idx < 0:
+                    idx = len(fixtures)-1
+                fixtures[idx].select(select_target)
+                break
+
+    if not selected_all and fixtures:
+        fixtures[-1].select(select_target)
+
+
+def select_next(context, select_target = False):
+    scene = context.scene
+    dmx = scene.dmx
+    selected_all = dmx.selectedFixtures()
+    fixtures = dmx.sortedFixtures()
+
+    for fixture in fixtures:
+        fixture.unselect()
+
+    for selected in selected_all:
+        for idx, fixture in enumerate(fixtures):
+            if fixture == selected:
+                idx += 1
+                if idx > len(fixtures)-1:
+                    idx = 0
+                fixtures[idx].select(select_target)
+                break
+
+    if not selected_all and fixtures:
+        fixtures[0].select(select_target)
+
+
 class DMX_OT_Fixture_SelectPrevious(Operator):
     bl_label = " "
     bl_idname = "dmx.fixture_previous"
@@ -557,26 +602,7 @@ class DMX_OT_Fixture_SelectPrevious(Operator):
     bl_options = {'UNDO'}
 
     def execute(self, context):
-        scene = context.scene
-        dmx = scene.dmx
-        selected_all = dmx.selectedFixtures()
-        fixtures = dmx.sortedFixtures()
-
-        for fixture in fixtures:
-            fixture.unselect()
-
-        for selected in selected_all:
-            for idx, fixture in enumerate(fixtures):
-                if fixture == selected:
-                    idx -= 1
-                    if idx < 0:
-                        idx = len(fixtures)-1
-                    fixtures[idx].select()
-                    break
-
-        if not selected_all and fixtures:
-            fixtures[-1].select()
-
+        select_previous(context)
         return {'FINISHED'}
 
 class DMX_OT_Fixture_SelectNext(Operator):
@@ -586,26 +612,27 @@ class DMX_OT_Fixture_SelectNext(Operator):
     bl_options = {'UNDO'}
 
     def execute(self, context):
-        scene = context.scene
-        dmx = scene.dmx
-        selected_all = dmx.selectedFixtures()
-        fixtures = dmx.sortedFixtures()
+        select_next(context)
+        return {'FINISHED'}
 
-        for fixture in fixtures:
-            fixture.unselect()
+class DMX_OT_Fixture_SelectPreviousTarget(Operator):
+    bl_label = " "
+    bl_idname = "dmx.fixture_previous_target"
+    bl_description = "Select Previous Fixture"
+    bl_options = {'UNDO'}
 
-        for selected in selected_all:
-            for idx, fixture in enumerate(fixtures):
-                if fixture == selected:
-                    idx += 1
-                    if idx > len(fixtures)-1:
-                        idx = 0
-                    fixtures[idx].select()
-                    break
+    def execute(self, context):
+        select_previous(context, select_target=True)
+        return {'FINISHED'}
 
-        if not selected_all and fixtures:
-            fixtures[0].select()
+class DMX_OT_Fixture_SelectNextTarget(Operator):
+    bl_label = " "
+    bl_idname = "dmx.fixture_next_target"
+    bl_description = "Select Next Fixture"
+    bl_options = {'UNDO'}
 
+    def execute(self, context):
+        select_next(context, select_target=True)
         return {'FINISHED'}
 
 class DMX_OT_Fixture_Item(Operator):

--- a/panels/programmer.py
+++ b/panels/programmer.py
@@ -52,6 +52,7 @@ class DMX_OT_Programmer_Unset_Ignore_Movement(Operator):
         for fixture in dmx.fixtures:
             if fixture in selected:
                 fixture.ignore_movement_dmx = False
+                fixture.ignore_movement_dmx = False
         return {'FINISHED'}
 
 class DMX_OT_Programmer_DeselectAll(Operator):
@@ -304,9 +305,21 @@ class DMX_PT_Programmer(Panel):
 
         if len(selected_fixtures) == 1:
             if selected_fixtures[0].has_attribute("Pan"):
-                box.prop(scene.dmx,"programmer_pan", text=_("Pan"), translate = False)
+                row = box.row()
+                col1 = row.column()
+                col1.prop(scene.dmx,"programmer_pan", text=_("Pan"), translate = False)
+                if selected_fixtures[0].ignore_movement_dmx == True:
+                    col2 = row.column()
+                    col2.operator("dmx.ignore_movement_false", text="", icon="UNLOCKED")
+                    col1.enabled = False
             if selected_fixtures[0].has_attribute("Tilt"):
-                box.prop(scene.dmx,"programmer_tilt", text=_("Tilt"), translate = False)
+                row = box.row()
+                col1 = row.column()
+                col1.prop(scene.dmx,"programmer_tilt", text=_("Tilt"), translate = False)
+                if selected_fixtures[0].ignore_movement_dmx == True:
+                    col2 = row.column()
+                    col2.operator("dmx.ignore_movement_false", text="", icon="UNLOCKED")
+                    col1.enabled = False
             if selected_fixtures[0].has_attribute("Zoom"):
                 box.prop(scene.dmx,"programmer_zoom", text=_("Zoom"), translate = False)
             if selected_fixtures[0].has_attribute("Gobo"):


### PR DESCRIPTION
- Provide shortcut to select prev/next Target (Ctrl-Shift-Left/Right)
- Ensure that keyframes are saved when programming position by Target
- Set Ignore pan/tilt DMX (lock target) after using Target to set position, to allow programming keyframes by Target
- Indicate pan/tilt lock and provide quick unlock in programmer
- Support multiple pan/tilt geometries for fixtures without Target

