### PR TITLE
Display device label (name, id, or dmx) in 2D view

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -795,6 +795,20 @@ class DMX(PropertyGroup):
                     obj.hide_set(not self.display_2D)
                     obj.hide_viewport = not self.display_2D
                     obj.hide_render = not self.display_2D
+                    if self.display_device_label == "NONE":
+                        obj.show_name = False
+                    elif self.display_device_label == "NAME":
+                        obj.name = f"{fixture.name}"
+                        obj.show_name = True
+                    elif self.display_device_label == "DMX":
+                        obj.name = f"{fixture.universe}.{fixture.address}"
+                        obj.show_name = True
+                    elif self.display_device_label == "FIXTURE_ID":
+                        if fixture.fixture_id:
+                            obj.name = f"{fixture.fixture_id}"
+                            obj.show_name = True
+                        else:
+                            obj.show_name = False
                 else:
                     obj.hide_set(self.display_2D)
                     if "pigtail" in obj.get("geometry_type", ""):
@@ -811,6 +825,17 @@ class DMX(PropertyGroup):
     display_2D: BoolProperty(
         name = _("Display 2D View"),
         default = False,
+        update = onDisplay2D)
+
+    display_device_label: EnumProperty(
+        name = _("Device Label"),
+        default = "NAME",
+        items= [
+                ("NONE", _("None"), "Do not display any label"),
+                ("NAME", _("Name"), "Name"),
+                ("DMX", _("DMX"), "DMX Address"),
+                ("FIXTURE_ID", _("Fixture ID"), "Fixture ID"),
+        ],
         update = onDisplay2D)
 
     def onSelectGeometries(self, context):

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -187,6 +187,9 @@ class DMX_PT_Setup_Viewport(Panel):
         row = layout.row()
         row.prop(context.scene.dmx,'display_2D')
         row = layout.row()
+        row.prop(context.scene.dmx,'display_device_label')
+        row.enabled = dmx.display_2D
+        row = layout.row()
         row.prop(context.scene.dmx,'display_pigtails')
         row = layout.row()
         row.prop(context.scene.dmx,'select_geometries')


### PR DESCRIPTION
![image](https://github.com/open-stage/blender-dmx/assets/3680926/78f2e479-0c01-48db-8dbc-a2f58f8713b3)
