### PR TITLE
Release 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ### Changelog
 
+### 1.4.3
+
+    * Fix Intel Mac crashing on Create New Show - remove unnecessary setup
+      class unregistration
+    * Display device label (name, id, or dmx) in 2D
+    * Rework 'Re-address only' to 'Advanced edit' for clarity
+    * Add Clear Project data button to clear the addon directory
+    * Add development related 'Reload BlenderDMX addon' button to Extras
+    * Update translations
+    * Reload profiles after data clearing or loading
+    * Fix Volume box migration - prevent always deleting volume box on file
+      load
+    * Fix gobo projection for fixtures without zoom
+    * Fix 'Clear/Clear all' in Programmer
+    * Fix ColorPicker when mixing single unit
+
 ### 1.4.2
 
     * Provide a way to export and import custom data from/to the Addon

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A DMX visualization tool inside <a href="https://blender.org">Blender</a>, desig
 
 First of all, make sure you have installed [Blender 3.4](https://www.blender.org/download/) or higher (Blender 4.x is supported). Then, download the `zip` file:
 
-### LATEST RELEASE (STABLE): v1.4.2
+### LATEST RELEASE (STABLE): v1.4.3
 
-   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.4.2.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.4.2/blenderDMX_v1.4.2.zip) file
+   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.4.3.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.4.3/blenderDMX_v1.4.3.zip) file
 
 ### ROLLING RELEASE (UNSTABLE)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,8 @@
 * Update translations, commit and give some time for translations to be done
+* To prevent weblate merge conflicts, in weblate:
+* Push translations, merge them fast in GitHub, then reset weblate to upstream
 
-cd i18n/
-pybabel extract -F babel.cfg -o messages.pot ../
-pybabel update -i messages.pot -d translations
-
-* Checkout a new branch `release_v_X.Y.Z`
+* Checkout a new branch `release_vX.Y.Z`
 * Add changes to CHANGELOG.md
 * Update versions (in text and in links) in README.md
 * Update __init__.py → bl_info → version

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 4, 2),
+    "version": (1, 4, 3),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",


### PR DESCRIPTION
* Fix Intel Mac crashing on Create New Show - remove unnecessary setup
  class unregistration
* Display device label (name, id, or dmx) in 2D
* Rework 'Re-address only' to 'Advanced edit' for clarity
* Add Clear Project data button to clear the addon directory
* Add development related 'Reload BlenderDMX addon' button to Extras
* Update translations
* Reload profiles after data clearing or loading
* Fix Volume box migration - prevent always deleting volume box on file
  load
* Fix gobo projection for fixtures without zoom
* Fix 'Clear/Clear all' in Programmer
* Fix ColorPicker when mixing single unit