### PR TITLE
Rework of GDTF geometries assembly process - use parenting instead of constrains

### DIFF
--- a/fixture.py
+++ b/fixture.py
@@ -5,6 +5,7 @@
 #   http://www.github.com/open-stage/BlenderDMX
 #
 
+import traceback
 import bpy
 import math
 import mathutils
@@ -397,12 +398,15 @@ class DMX_Fixture(PropertyGroup):
             # Link all other object to collection
             self.collection.objects.link(links[obj.name])
 
+        # Reparent children
+        for obj in model_collection.objects:
+            for child in obj.children:
+                if child.name in links:
+                    links[child.name].parent=links[obj.name]
         # Relink constraints
         for obj in self.collection.objects:
             for constraint in obj.constraints:
                 constraint.target = links[constraint.target.name]
-
-
 
         # (Edit) Reload old positions and rotations
         bpy.context.view_layer.update()
@@ -902,6 +906,7 @@ class DMX_Fixture(PropertyGroup):
                     light.object.data.keyframe_insert(data_path='color', frame=current_frame)
         except Exception as e:
             DMX_Log.log.error(f"Error updating RGB {e}")
+            traceback.print_exception(e)
         return rgb
 
 

--- a/fixture.py
+++ b/fixture.py
@@ -1298,7 +1298,6 @@ class DMX_Fixture(PropertyGroup):
                 obj.hide_viewport = hide
                 if current_frame and self.dmx_cache_dirty:
                     obj.keyframe_insert("hide_viewport", frame = current_frame)
-                break
         for light in self.lights: # CYCLES
             light_obj = light.object
             mix_factor = light_obj.data.node_tree.nodes.get("Mix").inputs["Factor"]

--- a/mvr.py
+++ b/mvr.py
@@ -310,6 +310,10 @@ def add_mvr_object(
         ob.location = Matrix(local_transform).to_translation()
         ob.rotation_mode = "XYZ"
         ob.rotation_euler = Matrix(local_transform).to_euler("XYZ")
+        # we use this for GDTF models, here it seems not to make any difference...:
+        #ob.rotation_euler[0] *=-1
+        #ob.rotation_euler[1] *=-1
+        #ob.rotation_euler[2] *=-1
         ob["file name"] = file
 
         ob.matrix_world = global_transform
@@ -331,7 +335,7 @@ def add_mvr_object(
 
     if len(object_collection.children) + len(object_collection.objects):
         group_collection.children.link(object_collection)
-        print("MVR object loaded in %.4f sec." % (time.time() - start_time))
+        print("INFO", "MVR object loaded in %.4f sec." % (time.time() - start_time))
         return object_collection
 
     return None


### PR DESCRIPTION
This makes many things better - object trees now have correct top-down rotations, offsets and placements.

Apply *-1 to rotations, this seems to fix several issues with assembly of complex trees.