### PR TITLE
Limit number of colors/gobos to 255

### DIFF
--- a/fixture.py
+++ b/fixture.py
@@ -355,7 +355,7 @@ class DMX_Fixture(PropertyGroup):
         self["slot_colors"] = []
         slot_colors = DMX_GDTF.get_wheel_slot_colors(gdtf_profile)
         if len(slot_colors)>1:
-            self["slot_colors"]=slot_colors
+            self["slot_colors"]=slot_colors[:255] # limit number of colors to an 8bit control channel
 
         links = {}
         base = self.get_root(model_collection)

--- a/gdtf.py
+++ b/gdtf.py
@@ -170,6 +170,9 @@ class DMX_GDTF():
             destination = pathlib.Path(sequence_path, f"image_{idx:04}{image.suffix}")
             if idx == 1:
                 first = str(destination.resolve())
+            if idx == 256: # more gobos then values on a channel, must stop
+                DMX_Log.log.info(f"Only 255 gobos are supported at the moment")
+                break
             destination.write_bytes(image.read_bytes())
             count = idx
         if first:


### PR DESCRIPTION
Currently, only 255 gobos or colorwheel colors are supported. Prevent errors if a fixture contains more.