### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ### Changelog
 
+### 1.5.0
+
+    * Fix showing fixtures after disabling 2D layout view
+    * Adding RGB glowing tube BlenderDMX provided device
+    * Adding Zoom and Gobos to the BlenderDMX provided Beam GDTF file
+    * Add custom cutoff_distance to lights to make gobos work in Eevee Next
+    * Remove onDepsgraph - prevents crashes and improves performance
+    * Big changes in architecture of the python code
+    * Fix several visible and invisible issues
+    * Translated using Weblate (Polish) [WaldiS], (Spanish) [Josman Goncalves Bravo], (German) [Ettore Atalan]
+    * Loading 3DS with apply transforms enabled for better results
+    * Apply position of referring geometry to geometry reference
+    * Create gobo plane only for fixtures with gobo for better performance
+    * Open shutter at 0 also at 255
+    * Limit number of colors/gobos to 255
+
+
 ### 1.4.4
 
     * Refactor GDTF assembling to use parent child relationship

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A DMX visualization tool inside <a href="https://blender.org">Blender</a>, desig
 
 First of all, make sure you have installed [Blender 3.4](https://www.blender.org/download/) or higher (Blender 4.x is supported). Then, download the `zip` file:
 
-### LATEST RELEASE (STABLE): v1.4.4
+### LATEST RELEASE (STABLE): v1.5.0
 
-   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.4.4.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.4.4/blenderDMX_v1.4.4.zip) file
+   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.5.0.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.5.0/blenderDMX_v1.5.0.zip) file
 
 ### ROLLING RELEASE (UNSTABLE)
 

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 4, 4),
+    "version": (1, 5, 0),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",


### PR DESCRIPTION
* Aligning release of the Addon with the Extension release
* Fix showing fixtures after disabling 2D layout view
* Adding RGB glowing tube BlenderDMX provided device
* Adding Zoom and Gobos to the BlenderDMX provided Beam GDTF file
* Add custom cutoff_distance to lights to make gobos work in Eevee Next
* Remove onDepsgraph - prevents crashes and improves performance
* Big changes in architecture of the python code
* Fix several visible and invisible issues
* Translated using Weblate (Polish) [WaldiS], (Spanish) [Josman Goncalves Bravo], (German) [Ettore Atalan]
* Loading 3DS with apply transforms enabled for better results
* Apply position of referring geometry to geometry reference
* Create gobo plane only for fixtures with gobo for better performance
* Open shutter at 0 also at 255
* Limit number of colors/gobos to 255