### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Changelog
 
+### 1.6.0
+
+    * Internal file reorganization, license headers, reformatting
+    * Make internal programmer to set values for Live DMX view
+    * Fixtures name autogeneration adjustments
+    * Add PosiStageNet (PSN) protocol with up to 10 PSN slots
+    * Add warning message for Blender 4.2. Add link to help to Extras
+    * Add Blender logo as gobo image to bundled beam
+    * Improve vectors of BlenderDMX logo gobo in bundled beam fixture
+
 ### 1.5.1
 
     * Fix python import on Win32 platform

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A DMX visualization tool inside <a href="https://blender.org">Blender</a>, desig
 
 First of all, make sure you have installed [Blender 3.4](https://www.blender.org/download/) or higher (Blender 4.x is supported). Then, download the `zip` file:
 
-### LATEST RELEASE (STABLE): v1.5.1
+### LATEST RELEASE (STABLE): v1.6.0
 
-   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.5.1.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.5.1/blenderDMX_v1.5.1.zip) file
+   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.6.0.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.6.0/blenderDMX_v1.6.0.zip) file
 
 ### ROLLING RELEASE (UNSTABLE)
 

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 5, 1),
+    "version": (1, 6, 0),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",


### PR DESCRIPTION
* Internal file reorganization, license headers, reformatting
* Make internal programmer to set values for Live DMX view
* Fixtures name autogeneration adjustments
* Add PosiStageNet (PSN) protocol with up to 10 PSN slots
* Add warning message for Blender 4.2. Add link to help to Extras
* Add Blender logo as gobo image to bundled beam
* Improve vectors of BlenderDMX logo gobo in bundled beam fixture
