### PR TITLE
Initial MVR export for fixtures

### DIFF
--- a/logging.py
+++ b/logging.py
@@ -51,7 +51,7 @@ class DMX_Log:
 
             console_log_handler = logging.StreamHandler()
             console_log_handler.setFormatter(log_formatter)
-            file_log_handler = RotatingFileHandler(path, backupCount=5, maxBytes=5000000, encoding="utf-8", mode="a")
+            file_log_handler = RotatingFileHandler(path, backupCount=5, maxBytes=800000, encoding="utf-8", mode="a")
             file_log_handler.setFormatter(log_formatter)
             log.addHandler(file_log_handler)
             log.addHandler(console_log_handler)

--- a/mvr.py
+++ b/mvr.py
@@ -368,7 +368,7 @@ def add_mvr_fixture(
 
     if existing_fixture is not None:
         existing_fixture.build(
-            f"{fixture.name} {layer_index}-{fixture_index}",
+            f"{fixture.name}",
             fixture.gdtf_spec,
             fixture.gdtf_mode,
             fixture.addresses[0].universe,

--- a/util.py
+++ b/util.py
@@ -131,6 +131,43 @@ def xyY2rgbaa(xyY):
 
     return (int(var_R * 100), int(var_G * 100), int(var_B * 100), 0)
 
+def rgb2xyY(sR, sG, sB):
+    # Convert RGB values to the 0-1 range
+    var_R = sR / 255
+    var_G = sG / 255
+    var_B = sB / 255
+
+    # Apply the gamma correction
+    if var_R > 0.04045:
+        var_R = ((var_R + 0.055) / 1.055) ** 2.4
+    else:
+        var_R = var_R / 12.92
+
+    if var_G > 0.04045:
+        var_G = ((var_G + 0.055) / 1.055) ** 2.4
+    else:
+        var_G = var_G / 12.92
+
+    if var_B > 0.04045:
+        var_B = ((var_B + 0.055) / 1.055) ** 2.4
+    else:
+        var_B = var_B / 12.92
+
+    # Convert to the 0-100 range
+    var_R = var_R * 100
+    var_G = var_G * 100
+    var_B = var_B * 100
+
+    # Convert to XYZ color space
+    X = var_R * 0.4124 + var_G * 0.3576 + var_B * 0.1805
+    Y = var_R * 0.2126 + var_G * 0.7152 + var_B * 0.0722
+    Z = var_R * 0.0193 + var_G * 0.1192 + var_B * 0.9505
+
+    # convert to xyY
+    Y = Y
+    x = X / ( X + Y + Z )
+    y = Y / ( X + Y + Z )
+    return x, y, Y
 
 def xyY2rgba(xyz):
     """Unused for now"""


### PR DESCRIPTION
Initial basic but working MVR export. Exports a single MVR layer with fixtures and their GDTFs. 

- [x] Most of the fixture related stuff
- [x]  Address
- [x] Color (add rgb2xyY)
- [x] Focus point
- [x] Fixture ids and unit numbers
- [x] Add migration for Target UUID
- [x] Ensure that Addressing is as described in MVR spec. BlenderDMX uses universe 0 for ArtNet, this is converted to Universe 1 for MVR.




