### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+### 1.7.0
+
+    * Initial MVR export - fixtures and focus points on one layer
+    * Ensure fixture name is unique when importing from MVR
+    * Fix dimmer if only one beam geometry exists
+
 ### 1.6.1
 
     * Add icon 'Center to selected' to Programmer

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A DMX visualization tool inside <a href="https://blender.org">Blender</a>, desig
 
 First of all, make sure you have installed [Blender 3.4](https://www.blender.org/download/) or higher (Blender 4.x is supported). Then, download the `zip` file:
 
-### LATEST RELEASE (STABLE): v1.6.1
+### LATEST RELEASE (STABLE): v1.7.0
 
-   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.6.1.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.6.1/blenderDMX_v1.6.1.zip) file
+   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.7.0.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.7.0/blenderDMX_v1.7.0.zip) file
 
 ### ROLLING RELEASE (UNSTABLE)
 

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 6, 1),
+    "version": (1, 7, 0),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",


### PR DESCRIPTION
* Initial MVR export - fixtures and focus points on one layer
* Ensure fixture name is unique when importing from MVR
* Fix dimmer if only one beam geometry exists
