### PR TITLE
Refactoring mvr.py

### DIFF
--- a/dmx.py
+++ b/dmx.py
@@ -28,8 +28,8 @@ from datetime import datetime
 import traceback
 from types import SimpleNamespace
 
-from . import pymvr
-from .mvr import extract_mvr_textures, process_mvr_child_list
+import pymvr
+from .mvr import load_mvr
 
 from . import param as param
 from . import fixture as fixture
@@ -1494,46 +1494,14 @@ class DMX(PropertyGroup):
 
     def addMVR(self, file_name):
 
-        start_time = time.time()
         bpy.context.window_manager.dmx.pause_render = True # this stops the render loop, to prevent slowness and crashes
-        already_extracted_files = {}
-        mvr_scene = pymvr.GeneralSceneDescription(file_name)
-        current_path = os.path.dirname(os.path.realpath(__file__))
-        extract_to_folder_path = os.path.join(current_path, "assets", "profiles")
-        media_folder_path = os.path.join(current_path, "assets", "models", "mvr")
-        extract_mvr_textures(mvr_scene, media_folder_path)
 
-        for layer_index, layer in enumerate(mvr_scene.layers):
-
-            layer_collection_name = layer.name or f"Layer {layer_index}"
-            if layer_collection_name in bpy.context.scene.collection.children:
-                layer_collection = bpy.context.scene.collection.children[layer_collection_name]
-            else:
-                layer_collection = bpy.data.collections.new(layer.name or f"Layer {layer_index}")
-                bpy.context.scene.collection.children.link(layer_collection)
-
-            g_name = layer.name or "Layer"
-            g_name = f"{g_name} {layer_index}"
-            fixture_group = FixtureGroup(g_name, layer.uuid)
-
-            process_mvr_child_list(
-                self,
-                layer.child_list,
-                layer_index,
-                extract_to_folder_path,
-                mvr_scene,
-                already_extracted_files,
-                layer_collection,
-                fixture_group
-            )
-            self.clean_up_empty_mvr_collections(layer_collection)
-            if len(layer_collection.all_objects) == 0:
-                bpy.context.scene.collection.children.unlink(layer_collection)
+        load_mvr(self, file_name)
 
         bpy.context.window_manager.dmx.pause_render = False # re-enable render loop
         DMX_GDTF.getManufacturerList()
         Profiles.DMX_Fixtures_Local_Profile.loadLocal()
-        print("INFO", "MVR scene loaded in %.4f sec." % (time.time() - start_time))
+
 
     def clean_up_empty_mvr_collections(self,collections):
         for collection in collections.children:
@@ -1775,6 +1743,4 @@ class DMX(PropertyGroup):
                 collection_info = nodes.node.nodes["Collection Info"]
                 collection = bpy.context.window_manager.dmx.collections_list
                 collection_info.inputs[0].default_value = collection
-
-
 

--- a/dmx.py
+++ b/dmx.py
@@ -28,7 +28,7 @@ from datetime import datetime
 import traceback
 from types import SimpleNamespace
 
-import pymvr
+from . import pymvr
 from .mvr import load_mvr
 
 from . import param as param

--- a/io_scene_3ds/import_3ds.py
+++ b/io_scene_3ds/import_3ds.py
@@ -262,6 +262,8 @@ def add_texture_to_material(image, contextWrapper, pct, extend, alpha, scale, of
         img_wrap = contextWrapper.base_color_texture
         links.new(mixer.outputs[0], shader.inputs['Base Color'])
         links.new(img_wrap.node_image.outputs[0], mixer.inputs[2])
+        if not shader.inputs['Alpha'].is_linked:
+            links.new(img_wrap.node_image.outputs[1], shader.inputs['Alpha'])
     elif mapto == 'ROUGHNESS':
         img_wrap = contextWrapper.roughness_texture
     elif mapto == 'METALLIC':

--- a/io_scene_3ds/import_3ds.py
+++ b/io_scene_3ds/import_3ds.py
@@ -1719,7 +1719,7 @@ def process_next_chunk(context, file, previous_chunk, imported_objects, CONSTRAI
 def load_3ds(filepath, context, CONSTRAIN=10.0, UNITS=False, IMAGE_SEARCH=True,
              FILTER=None, KEYFRAME=True, APPLY_MATRIX=True, CONVERSE=None, CURSOR=False):
 
-    print("importing 3DS: %r..." % (filepath), end="")
+    print("importing 3DS: %r..." % (Path(filepath).name), end="")
 
     if bpy.ops.object.select_all.poll():
         bpy.ops.object.select_all(action='DESELECT')
@@ -1732,7 +1732,7 @@ def load_3ds(filepath, context, CONSTRAIN=10.0, UNITS=False, IMAGE_SEARCH=True,
     # here we go!
     read_chunk(file, current_chunk)
     if current_chunk.ID != PRIMARY:
-        print("\tFatal Error:  Not a valid 3ds file: %r" % filepath)
+        print("\tFatal Error:  Not a valid 3ds file: %r" % Path(filepath).name)
         file.close()
         return
 

--- a/mvr.py
+++ b/mvr.py
@@ -420,7 +420,7 @@ def load_mvr(dmx, file_name):
         get_child_list(dmx, mscale, mvr_scene, layer.child_list, layer_idx,
                        folder_path, extracted, layer_collection, fixture_group)
 
-        if len(layer_collection.all_objects) == 0:
+        if len(layer_collection.all_objects) == 0 and layer_collection.name in layer_collect.children:
             layer_collect.children.unlink(layer_collection)
 
     transform_objects(mvr_scene.layers, mscale)

--- a/mvr.py
+++ b/mvr.py
@@ -179,6 +179,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
     geometrys = []
     active_collect = None
     context_matrix = mscale
+    collection = group_collect
     dmx = bpy.context.scene.dmx
     previous_mvr_object = None
     for existing_mvr_object in dmx.mvr_objects:
@@ -228,6 +229,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
         active_collect = bpy.data.collections.new(obj_name)
         create_mvr_props(active_collect, class_name, name, uid)
         group_collect.children.link(active_collect)
+        collection = active_collect
 
     if active_collect is None:
         active_collect = next((col for col in data_collect if col.get('UUID') == uid), False)
@@ -240,8 +242,8 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
         obj_mtx = get_matrix(geometry, mscale)
         extract_mvr_object(file, mvr_scene, folder, extracted)
         object_collect = add_mvr_object(idx, geometry, obj_mtx, active_collect, file)
-        if object_collect and object_collect.name not in group_collect.children: 
-            group_collect.children.link(object_collect)
+        if object_collect and object_collect.name not in collection.children: 
+            collection.children.link(object_collect)
 
     for idx, symbol in enumerate(symbols):
         symbol_type = symbol.__class__.__name__
@@ -253,7 +255,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
             if not len(name):
                 name = '%s %d' % (class_name, idx) if idx >= 1 else class_name
             symbol_object = object_data.new(name, None)
-            group_collect.objects.link(symbol_object)
+            collection.objects.link(symbol_object)
             symbol_object.matrix_world = symbol_mtx
             symbol_object.empty_display_size = 0.01
             symbol_object.empty_display_type = 'ARROWS'

--- a/mvr.py
+++ b/mvr.py
@@ -143,7 +143,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
         print("adding %s... %s" % (node_type, mesh_name))
         if len(ob_exist):
             existing = next((ob for ob in ob_exist), False)
-        elif len(mesh_exist) and not new_object:
+        elif len(mesh_exist) and not existing:
             for mesh in mesh_exist:
                 mesh_id = mesh.get('MVR Name')
                 existing = object_data.new(mesh_id, mesh)

--- a/mvr.py
+++ b/mvr.py
@@ -143,12 +143,13 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
         print("adding %s... %s" % (node_type, mesh_name))
         if len(ob_exist):
             new_object = next((ob for ob in ob_exist), False)
+            if new_object:
+                imported_objects.append(new_object)
         elif len(mesh_exist) and not new_object:
             for mesh in mesh_exist:
                 mesh_id = mesh.get('MVR Name')
                 new_object = object_data.new(mesh_id, mesh)
             if new_object:
-                objectData.setdefault(uid, []).append(new_object)
                 imported_objects.append(new_object)
         elif not new_object:
             file_name = os.path.join(folder, file)

--- a/mvr.py
+++ b/mvr.py
@@ -166,7 +166,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
                 elif ob.name in layer_collect.collection.objects:
                     active_layer.collection.objects.unlink(ob)
                 if ob.parent is None:
-                    ob.matrix_world = world_matrix
+                    ob.matrix_world = world_matrix @ ob.matrix_world.copy()
                 if ob.name not in collect.objects:
                     collect.objects.link(ob)
             objectData.setdefault(uid, collect)

--- a/mvr.py
+++ b/mvr.py
@@ -143,8 +143,6 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
         print("adding %s... %s" % (node_type, mesh_name))
         if len(ob_exist):
             new_object = next((ob for ob in ob_exist), False)
-            if new_object:
-                imported_objects.append(new_object)
         elif len(mesh_exist) and not new_object:
             for mesh in mesh_exist:
                 mesh_id = mesh.get('MVR Name')

--- a/mvr.py
+++ b/mvr.py
@@ -239,7 +239,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
             symbol_object = object_data.new(name, None)
             group_collect.objects.link(symbol_object)
             symbol_object.matrix_world = symbol_mtx
-            symbol_object.empty_display_size = 0.1
+            symbol_object.empty_display_size = 0.01
             symbol_object.empty_display_type = 'ARROWS'
             symbol_object.instance_type = 'COLLECTION'
             symbol_object.instance_collection = symbol_collect

--- a/mvr.py
+++ b/mvr.py
@@ -99,11 +99,11 @@ def get_child_list(dmx, mscale, mvr_scene, child_list, layer_index, folder_path,
 
     for group_idx, group in enumerate(child_list.group_objects):
         if hasattr(group, "child_list") and group.child_list:
-            layergroup_idx = layer_index
+            layergroup_idx = f"{layer_index}-{group_idx}"
             group_name = group.name or "Group"
             group_name =  '%s %d' % (group_name, group_idx) if group_idx >= 1 else group_name
             fixture_group = FixtureGroup(group_name, group.uuid)
-            get_child_list(dmx, mscale, mvr_scene, group.child_list, layer_index,
+            get_child_list(dmx, mscale, mvr_scene, group.child_list, layergroup_idx,
                            folder_path, extracted, layer_collection, fixture_group)
 
     for obj in viewlayer.active_layer_collection.collection.all_objects:

--- a/mvr.py
+++ b/mvr.py
@@ -461,7 +461,7 @@ def load_mvr(dmx, file_name):
             obj_name = obj.name.split('.')[0]
             if obj.is_instancer:
                 insta_name = '%s %d' % (obj_name, idx) if idx >= 1 else obj_name
-                obj.name = '%s_%d' % (insta_name, obid)
+                obj.name = '%s_%d' % (insta_name.split('_')[0], obid)
             elif obj.name[-3:].isdigit() and obj.name[-4] == '.':
                 obj.name = '%s %d' % (obj_name, obid)
 

--- a/mvr.py
+++ b/mvr.py
@@ -20,12 +20,12 @@ import os
 import bpy
 import time
 import json
-import pymvr
+from . import pymvr
 from pathlib import Path
 from mathutils import Matrix
 from .logging import DMX_Log
 from .group import FixtureGroup
-from io_scene_3ds.import_3ds import load_3ds
+from .io_scene_3ds.import_3ds import load_3ds
 from .util import xyY2rgbaa, create_unique_fixture_name
 
 

--- a/mvr.py
+++ b/mvr.py
@@ -137,7 +137,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
         reference = collect.get('Reference')
         scale_factor = 0.001 if file.split('.')[-1] == '3ds' else 1.0
         mesh_exist = next((msh for msh in mesh_data if msh.name == mesh_name), False)
-        exist = any(ob.data.name == mesh_name for ob in collect.objects)
+        exist = any(ob.data and ob.data.name == mesh_name for ob in collect.objects)
         world_matrix = mtx @ Matrix.Scale(scale_factor, 4)
         print("adding %s... %s" % (node_type, mesh_name))
 

--- a/mvr.py
+++ b/mvr.py
@@ -179,6 +179,24 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
     geometrys = []
     active_collect = None
     context_matrix = mscale
+    dmx = bpy.context.scene.dmx
+    previous_mvr_object = None
+    for existing_mvr_object in dmx.mvr_objects:
+        if existing_mvr_object.uuid == mvr_object.uuid:
+            previous_mvr_object = existing_mvr_object
+            DMX_Log.log.info("Updating existing mvr object")
+            for child in existing_mvr_object.collection.children:
+                for obj in child.objects:
+                    bpy.data.objects.remove(obj)
+            break
+    if previous_mvr_object:
+        dmx_mvr_object = previous_mvr_object
+    else:
+        dmx_mvr_object = dmx.mvr_objects.add()
+        dmx_mvr_object.name = name
+        dmx_mvr_object.uuid = mvr_object.uuid
+        dmx_mvr_object.object_type = mvr_object.__class__.__name__
+        dmx_mvr_object.collection = bpy.data.collections.new(mvr_object.uuid)
 
     if isinstance(mvr_object, pymvr.Symbol):
         symbols.append(mvr_object)

--- a/mvr.py
+++ b/mvr.py
@@ -20,13 +20,13 @@ import os
 import bpy
 import time
 import json
-from . import pymvr
+import pymvr
 from pathlib import Path
 from mathutils import Matrix
 from .logging import DMX_Log
 from .group import FixtureGroup
+from io_scene_3ds.import_3ds import load_3ds
 from .util import xyY2rgbaa, create_unique_fixture_name
-from .io_scene_3ds.import_3ds import load_3ds
 
 
 auxData = {}
@@ -60,7 +60,7 @@ def get_child_list(dmx, mscale, mvr_scene, child_list, layer_index, folder_path,
         viewlayer.active_layer_collection = viewport
 
     for truss_idx, truss_obj in enumerate(child_list.trusses):
-        print("creating Truss collection... %s" % truss_obj.name)
+        print("creating Truss... %s" % truss_obj.name)
 
         if fixture_group is None:
             group_name = truss_obj.name or "Truss"
@@ -110,7 +110,7 @@ def get_child_list(dmx, mscale, mvr_scene, child_list, layer_index, folder_path,
         obj.select_set(True)
 
 
-def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extracted, group_collect):
+def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracted, group_collect):
 
     uid = mvr_object.uuid
     name = mvr_object.name
@@ -124,27 +124,31 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
     symdef_id = isinstance(mvr_object, pymvr.Symdef)
     current_path = os.path.dirname(os.path.realpath(__file__))
     folder = os.path.join(current_path, "assets", "models", "mvr")
-    if not symdef_id:
-        name = '%s %d' % (name, mvr_index) if name in data_collect else name
     print("creating %s... %s" % (class_name, name))  
 
     def add_mvr_object(idx, node, mtx, collect, file=""):
-        imported_objects = []
+        node_type = node.__class__.__name__
         item_name = Path(file).name
         mesh_name = Path(file).stem
         mesh_data = bpy.data.meshes
-        node_type = node.__class__.__name__
+        imported_objects = []
+        if not symdef_id:
+            collect['Reference'] = mesh_name
+        reference = collect.get('Reference')
         scale_factor = 0.001 if file.split('.')[-1] == '3ds' else 1.0
-        mesh_exist = [msh for msh in mesh_data if msh.name == mesh_name]
+        mesh_exist = next((msh for msh in mesh_data if msh.name == mesh_name), False)
+        exist = any(ob for ob in object_data if ob.get('Reference') and reference == uid)
         world_matrix = mtx @ Matrix.Scale(scale_factor, 4)
-        
         print("adding %s... %s" % (node_type, mesh_name))
-        if len(mesh_exist):
-            for mesh in mesh_exist:
-                mesh_id = mesh.get('MVR Name')
-                new_object = object_data.new(mesh_id, mesh)
-                imported_objects.append(new_object)
-        else:
+
+        if mesh_exist:
+            if not exist:
+                new_obj = next((ob for ob in object_data if ob.get('UUID') == reference), False)
+                if not new_obj:
+                    mesh_id = mesh_exist.get('MVR Name')
+                    new_obj = object_data.new(mesh_id, mesh_exist)
+                imported_objects.append(new_obj)
+        elif not exist:
             file_name = os.path.join(folder, file)
             if os.path.isfile(file_name):
                 if file.split('.')[-1] == 'glb':
@@ -152,11 +156,10 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
                 else:
                     load_3ds(file_name, bpy.context, KEYFRAME=False, APPLY_MATRIX=False)
                 imported_objects.extend(list(viewlayer.objects.selected))
-
         for ob in imported_objects:
             ob.rotation_mode = 'XYZ'
             obname = ob.name.split('.')[0]
-            create_mvr_props(ob, class_name, obname, uid, mesh_name)
+            create_mvr_props(ob, class_name, obname, mesh_name, uid)
             if ob.data:
                 ob.data.name = mesh_name
                 create_mvr_props(ob.data, node_type, obname, uid, item_name) 
@@ -164,10 +167,10 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
                 ob.users_collection[0].objects.unlink(ob)
             elif ob.name in layer_collect.collection.objects:
                 active_layer.collection.objects.unlink(ob)
-            if ob.name not in collect.objects:
-                collect.objects.link(ob)
             if ob.parent is None:
                 ob.matrix_world = world_matrix
+            if ob.name not in collect.objects:
+                collect.objects.link(ob)
         objectData.setdefault(uid, collect)
         imported_objects.clear()
         viewlayer.update()
@@ -186,15 +189,6 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
     elif not symdef_id and mvr_object.geometries:
         symbols += mvr_object.geometries.symbol
         geometrys += mvr_object.geometries.geometry3d
-        if (len(geometrys) + len(symbols)) > 1:
-            if mvr_object.name is not None and len(mvr_object.name):
-                mvr_name = '%s - %s %d' % (class_name, mvr_object.name, mvr_index)
-            else:
-                mvr_name = '%s %d' % (class_name, mvr_index) if mvr_index >= 1 else class_name
-            print("creating extra collection", mvr_name)
-            active_collect = bpy.data.collections.new(mvr_name)
-            create_mvr_props(active_collect, class_name, mvr_object.name, mvr_object.uuid)
-            group_collect.children.link(active_collect)
     else:
         symbols += mvr_object.symbol
         geometrys += mvr_object.geometry3d
@@ -206,32 +200,37 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
             active_collect = data_collect.get(uid)
             if active_collect is None:
                 active_collect = data_collect.new(uid)
-        create_mvr_props(active_collect, class_name, uid)
+        if active_collect.get('MVR Class') is None:
+            create_mvr_props(active_collect, class_name, uid)
         active_collect.hide_render = True
+    elif (len(geometrys) + len(symbols)) > 1:
+        if mvr_object.name is not None and len(mvr_object.name):
+            obj_name = '%s - %s %d' % (class_name, mvr_object.name, mvr_idx)
+        else:
+            obj_name = '%s %d' % (class_name, mvr_idx) if mvr_idx >= 1 else class_name
+        print("creating extra collection", obj_name)
+        active_collect = bpy.data.collections.new(obj_name)
+        create_mvr_props(active_collect, class_name, name, uid)
+        group_collect.children.link(active_collect)
 
     if active_collect is None:
         active_collect = next((col for col in data_collect if col.get('UUID') == uid), False)
         if not active_collect and not len(symbols):
             active_collect = data_collect.new(name)
-            group_collect.children.link(active_collect)
             create_mvr_props(active_collect, class_name, name, uid)
 
     for idx, geometry in enumerate(geometrys):
         file = geometry.file_name
-        existing = any(ob for ob in object_data if ob.get('Reference') == Path(file).stem)
-        if not existing:
-            if not active_collect:
-                active_collect = data_collect.new(name)
-            obj_mtx = get_matrix(geometry, mscale)
-            extract_mvr_object(file, mvr_scene, folder, extracted)
-            object_collect = add_mvr_object(idx, geometry, obj_mtx, active_collect, file)
-            if object_collect and object_collect.name not in group_collect.children:
-                group_collect.children.link(object_collect)
+        obj_mtx = get_matrix(geometry, mscale)
+        extract_mvr_object(file, mvr_scene, folder, extracted)
+        object_collect = add_mvr_object(idx, geometry, obj_mtx, active_collect, file)
+        if object_collect and object_collect.name not in group_collect.children: 
+            group_collect.children.link(object_collect)
 
     for idx, symbol in enumerate(symbols):
         symbol_type = symbol.__class__.__name__
         symbol_mtx = get_matrix(symbol, context_matrix)
-        if not isinstance(mvr_object, pymvr.Symdef):
+        if not symdef_id:
             symbol_mtx = get_matrix(mvr_object, symbol_mtx)
         symbol_collect = data_collect.get(symbol.symdef)
         if symbol_collect:
@@ -240,7 +239,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
             symbol_object = object_data.new(name, None)
             group_collect.objects.link(symbol_object)
             symbol_object.matrix_world = symbol_mtx
-            symbol_object.empty_display_size = 0.01
+            symbol_object.empty_display_size = 0.1
             symbol_object.empty_display_type = 'ARROWS'
             symbol_object.instance_type = 'COLLECTION'
             symbol_object.instance_collection = symbol_collect
@@ -386,7 +385,7 @@ def load_mvr(dmx, file_name):
     classes = auxdata.classes
     symdefs = auxdata.symdefs
 
-    for def_index, symdef in enumerate(symdefs):
+    for aux_idx, symdef in enumerate(symdefs):
         if aux_dir and symdef.name in aux_dir.children:
             aux_collection = aux_dir.children.get(symdef.name)
         elif symdef.name in data_collect:
@@ -395,12 +394,12 @@ def load_mvr(dmx, file_name):
             aux_collection = data_collect.new(symdef.name)
 
         auxData.setdefault(symdef.uuid, aux_collection)
-        process_mvr_object(context, mvr_scene, symdef, def_index,
+        process_mvr_object(context, mvr_scene, symdef, aux_idx,
                            mscale, extracted, aux_collection)
 
         if hasattr(symdef, "child_list") and symdef.child_list:
             get_child_list(dmx, mscale, mvr_scene, symdef.child_list,
-                           aux_index, folder_path, extracted, aux_collection)
+                           aux_idx, folder_path, extracted, aux_collection)
 
     for layer_idx, layer in enumerate(mvr_scene.layers):
         layer_class = layer.__class__.__name__

--- a/mvr.py
+++ b/mvr.py
@@ -129,20 +129,19 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
     print("creating %s... %s" % (class_name, name))  
 
     def add_mvr_object(idx, node, mtx, collect, file=""):
-        existing = False
         imported_objects = []
         item_name = Path(file).name
         mesh_name = Path(file).stem
         mesh_data = bpy.data.meshes
         node_type = node.__class__.__name__
         scale_factor = 0.001 if file.split('.')[-1] == '3ds' else 1.0
-        ob_exist = [ob for ob in object_data if ob.get('Reference') == mesh_name]
+        existing = next((ob for ob in object_data if ob.get('Reference') == mesh_name), False)
         mesh_exist = [msh for msh in mesh_data if msh.name == mesh_name]
         world_matrix = mtx @ Matrix.Scale(scale_factor, 4)
         
         print("adding %s... %s" % (node_type, mesh_name))
-        if len(ob_exist):
-            existing = next((ob for ob in ob_exist), False)
+        if existing:
+            pass
         elif len(mesh_exist) and not existing:
             for mesh in mesh_exist:
                 mesh_id = mesh.get('MVR Name')

--- a/mvr.py
+++ b/mvr.py
@@ -129,7 +129,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
     print("creating %s... %s" % (class_name, name))  
 
     def add_mvr_object(idx, node, mtx, collect, file=""):
-        new_object = False
+        existing = False
         imported_objects = []
         item_name = Path(file).name
         mesh_name = Path(file).stem
@@ -142,14 +142,14 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
         
         print("adding %s... %s" % (node_type, mesh_name))
         if len(ob_exist):
-            new_object = next((ob for ob in ob_exist), False)
+            existing = next((ob for ob in ob_exist), False)
         elif len(mesh_exist) and not new_object:
             for mesh in mesh_exist:
                 mesh_id = mesh.get('MVR Name')
-                new_object = object_data.new(mesh_id, mesh)
-            if new_object:
-                imported_objects.append(new_object)
-        elif not new_object:
+                existing = object_data.new(mesh_id, mesh)
+            if existing:
+                imported_objects.append(existing)
+        elif not existing:
             file_name = os.path.join(folder, file)
             if os.path.isfile(file_name):
                 if file.split('.')[-1] == 'glb':
@@ -173,7 +173,8 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_index, mscale, extrac
             ob.rotation_mode = 'XYZ'
             if ob.parent is None:
                 ob.matrix_world = world_matrix
-        objectData.setdefault(uid, collect)
+        if not existing:
+            objectData.setdefault(uid, collect)
         imported_objects.clear()
         viewlayer.update()
         return collect


### PR DESCRIPTION
Complete refactor of mvr.py including:

1. Avoid importing meshes multiple times
2. Use collection instances for symbol objects
3. Use already imported collections instead of creating new
4. Use object uuids instead of hashlib or collection names
5. Create custom properties for MVR class, name, uuid and reference
6. Fixed matrix transformations
7. Fixed names if they are doubles
8. Importing is now about 10 times faster