### PR TITLE
Import export version checks

### DIFF
--- a/in_out_mvr.py
+++ b/in_out_mvr.py
@@ -1,15 +1,28 @@
 import bpy
 import os
-from bpy_extras.io_utils import (
-    ImportHelper,
-    ExportHelper,
-)
+
+from bpy_extras.io_utils import ImportHelper, ExportHelper
+
+if bpy.app.version >= (4, 2):
+    from bpy_extras.io_utils import poll_file_object_drop
+
 from bpy.props import (
     StringProperty,
     CollectionProperty,
 )
 
-class DMX_OT_Import_MVR(bpy.types.Operator, ImportHelper):
+from bpy.types import Operator
+
+from threading import Timer
+
+
+def createDMXcollection():
+    dmx = bpy.context.scene.dmx
+    if not dmx.collection:
+        bpy.context.scene.dmx.new()
+
+
+class DMX_OT_Import_MVR(Operator, ImportHelper):
     """Import My Virtual Rig"""
 
     bl_idname = "dmx.import_mvr_into_scene"
@@ -22,14 +35,15 @@ class DMX_OT_Import_MVR(bpy.types.Operator, ImportHelper):
     directory: StringProperty(subtype="DIR_PATH")
 
     def draw(self, context):
+        dmx = context.scene.dmx
+        if not dmx.collection:
+            Timer(0, createDMXcollection, ()).start()
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
 
     def execute(self, context):
         dmx = context.scene.dmx
-        if not dmx.collection:
-            context.scene.dmx.new()
         for file in self.files:
             if not file.name:
                 continue
@@ -39,7 +53,7 @@ class DMX_OT_Import_MVR(bpy.types.Operator, ImportHelper):
         return {"FINISHED"}
 
 
-class DMX_OT_Export_MVR(bpy.types.Operator, ExportHelper):
+class DMX_OT_Export_MVR(Operator, ExportHelper):
     """Export My Virtual Rig"""
 
     bl_idname = "dmx.export_mvr_from_scene"
@@ -49,15 +63,16 @@ class DMX_OT_Export_MVR(bpy.types.Operator, ExportHelper):
     filename_ext = ".mvr"
 
     def draw(self, context):
+        dmx = context.scene.dmx
+        if not dmx.collection:
+            Timer(0, createDMXcollection, ()).start()
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
 
     def execute(self, context):
         dmx = context.scene.dmx
-        if not dmx.collection:
-            context.scene.dmx.new()
-        dmx = context.scene.dmx
+        print(self.filepath)
         result = dmx.export_mvr(self.filepath)
 
         if result.ok:
@@ -68,12 +83,19 @@ class DMX_OT_Export_MVR(bpy.types.Operator, ExportHelper):
         return {"FINISHED"}
 
 
-class DMX_IO_FH_MVR(bpy.types.FileHandler):
-    bl_idname = "IO_FH_mvr"
-    bl_label = "MVR"
-    bl_import_operator = "dmx.import_mvr_into_scene"
-    bl_export_operator = "dmx.export_mvr_from_scene"
-    bl_file_extensions = ".mvr"
+if bpy.app.version >= (4, 1):
+
+    class DMX_IO_FH_MVR(bpy.types.FileHandler):
+        bl_idname = "IO_FH_mvr"
+        bl_label = "MVR"
+        bl_import_operator = "dmx.import_mvr_into_scene"
+        bl_export_operator = "dmx.export_mvr_from_scene"
+        bl_file_extensions = ".mvr"
+
+        @classmethod
+        def poll_drop(cls, context):
+            if bpy.app.version >= (4, 2):
+                return poll_file_object_drop(context)
 
 
 def menu_func_export(self, context):
@@ -87,14 +109,16 @@ def menu_func_import(self, context):
 def register():
     bpy.utils.register_class(DMX_OT_Import_MVR)
     bpy.utils.register_class(DMX_OT_Export_MVR)
-    bpy.utils.register_class(DMX_IO_FH_MVR)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
     bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
+    if bpy.app.version >= (4, 1):
+        bpy.utils.register_class(DMX_IO_FH_MVR)
 
 
 def unregister():
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
     bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
-    bpy.utils.unregister_class(DMX_IO_FH_MVR)
+    if bpy.app.version >= (4, 1):
+        bpy.utils.unregister_class(DMX_IO_FH_MVR)
     bpy.utils.unregister_class(DMX_OT_Import_MVR)
     bpy.utils.unregister_class(DMX_OT_Export_MVR)


### PR DESCRIPTION
This ensures that:

In/Out GDTF/MVR dialogs work in 3.4, 4.0, 4.1, 4.2.
Drag and drop works in 4.2.
Import of MVR on new startup (when DMX scene has not yet been created) now works and does not crash blender.