### PR TITLE
mvr: Improved scene reset if mvr imported again

### DIFF
--- a/mvr.py
+++ b/mvr.py
@@ -159,7 +159,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
                     ob.matrix_world = trans_matrix(transform)
         else:
             if mesh_exist:
-                mesh_id = mesh_exist.get('MVR Name')
+                mesh_id = mesh_exist.get('MVR Name', mesh_name)
                 new_object = object_data.new(mesh_id, mesh_exist)
                 imported_objects.append(new_object)
             else:
@@ -168,7 +168,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
                     if file.split('.')[-1] == 'glb':
                         bpy.ops.import_scene.gltf(filepath=file_name)
                     else:
-                        load_3ds(file_name, bpy.context, KEYFRAME=False, APPLY_MATRIX=False)
+                        load_3ds(file_name, context, KEYFRAME=False, APPLY_MATRIX=False)
                     imported_objects.extend(list(viewlayer.objects.selected))
             for ob in imported_objects:
                 ob.rotation_mode = 'XYZ'

--- a/mvr.py
+++ b/mvr.py
@@ -59,8 +59,8 @@ def get_matrix(obj, mtx):
 
 
 def trans_matrix(trans_mtx):
-    trans = list(trans_mtx)
-    trans_matrix = Matrix((trans[:3]+[0], trans[3:6]+[0], trans[6:9]+[0], trans[9:]+[1])).transposed()
+    mtx = list(trans_mtx)
+    trans_matrix = Matrix((mtx[:3]+[0], mtx[3:6]+[0], mtx[6:9]+[0], mtx[9:]+[1])).transposed()
     return trans_matrix
 
 


### PR DESCRIPTION
1. Scene is now reseted correctly if same mvr imported again
2. Objects got a transform property wich saves the original transformation into a 4x3 matrix
3. The 4x3 matrix can be used to export the object again with the correct matrix
4. added code wich was previously removed
5. exchanged prints with dmx log