### PR TITLE
gdtf: Check model dimensions before 3ds transform

### DIFF
--- a/gdtf.py
+++ b/gdtf.py
@@ -235,7 +235,7 @@ class DMX_GDTF:
                 load_3ds(file_name, bpy.context, FILTER={'MESH'}, KEYFRAME=False, APPLY_MATRIX=False)
                 obj_dimension = Vector((model.length, model.width, model.height))
                 for ob in bpy.context.selected_objects:
-                    if obj_dimension.to_tuple(3) != ob.dimensions.to_tuple(3):
+                    if ob.dimensions.to_tuple(3) > obj_dimension.to_tuple(3):
                         ob.data.transform(Matrix.Scale(0.001, 4))
             except Exception as e:
                 DMX_Log.log.error(f"Error loading a 3DS file {e}")

--- a/gdtf.py
+++ b/gdtf.py
@@ -24,7 +24,7 @@ import math
 import hashlib
 from types import SimpleNamespace
 import pathlib
-from mathutils import Euler, Matrix
+from mathutils import Euler, Matrix, Vector
 
 from . import pygdtf
 from .logging import DMX_Log
@@ -233,8 +233,10 @@ class DMX_GDTF:
             file_name = os.path.join(extract_to_folder_path, inside_zip_path)
             try:
                 load_3ds(file_name, bpy.context, FILTER={'MESH'}, KEYFRAME=False, APPLY_MATRIX=False)
+                obj_dimension = Vector((model.length, model.width, model.height))
                 for ob in bpy.context.selected_objects:
-                    ob.data.transform(Matrix.Scale(0.001, 4))
+                    if obj_dimension.to_tuple(3) != ob.dimensions.to_tuple(3):
+                        ob.data.transform(Matrix.Scale(0.001, 4))
             except Exception as e:
                 DMX_Log.log.error(f"Error loading a 3DS file {e}")
                 traceback.print_exception(e)


### PR DESCRIPTION
In some gdtf files I tested the model dimensions are equal with blender dimensions.  This commit checks the dimensions before transforming the 3ds models to vectorworks scale.