### PR TITLE
Eliminate some of the print statements and whitespace, to pass pre-commit hook

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -30,11 +30,11 @@ class DMX_Lang:
         this_dir = os.path.dirname(os.path.abspath(__file__))
         localedir = os.path.join(this_dir, "translations")
         try:
-            print("Setting up language:", locale)
+            print("INFO", "Setting up language:", locale)
             lang = gettext.translation("messages", localedir=localedir, languages=[locale])
         except:
             lang = gettext.translation("messages", localedir=localedir, languages=["en_US"])  # fallback
-            print(f"Setting language did not work, locale {locale} probably not created yet")
+            print("INFO", f"Setting language did not work, locale {locale} probably not created yet")
         finally:
             DMX_Lang._ = lang.gettext
 

--- a/in_out_mvr.py
+++ b/in_out_mvr.py
@@ -1,5 +1,6 @@
 import bpy
 import os
+from .logging import DMX_Log
 
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 
@@ -72,7 +73,7 @@ class DMX_OT_Export_MVR(Operator, ExportHelper):
 
     def execute(self, context):
         dmx = context.scene.dmx
-        print(self.filepath)
+        DMX_Log.log.info(self.filepath)
         result = dmx.export_mvr(self.filepath)
 
         if result.ok:

--- a/mvr.py
+++ b/mvr.py
@@ -188,7 +188,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
                 create_mvr_props(ob, class_name, obname, mesh_name, uid)
                 if ob.data:
                     ob.data.name = mesh_name
-                    create_mvr_props(ob.data, node_type, obname, uid, item_name) 
+                    create_mvr_props(ob.data, node_type, obname, uid, item_name)
                 if len(ob.users_collection) and ob.name in ob.users_collection[0].objects:
                     ob.users_collection[0].objects.unlink(ob)
                 elif ob.name in layer_collect.collection.objects:
@@ -273,7 +273,7 @@ def process_mvr_object(context, mvr_scene, mvr_object, mvr_idx, mscale, extracte
         obj_mtx = get_matrix(geometry, mscale)
         extract_mvr_object(file, mvr_scene, folder, extracted)
         object_collect = add_mvr_object(idx, geometry, obj_mtx, active_collect, file)
-        if object_collect and object_collect.name not in collection.children and object_collect != collection: 
+        if object_collect and object_collect.name not in collection.children and object_collect != collection:
             collection.children.link(object_collect)
 
     for idx, symbol in enumerate(symbols):
@@ -499,7 +499,7 @@ def load_mvr(dmx, file_name):
                     auxcollect.children.link(sym_collect)
                     if sym_name in (None, 'None'):
                         sym_name = 'None Layer'
-                sym_collect.name = sym_name 
+                sym_collect.name = sym_name
 
     for laycollect in layer_collect.children:
         if laycollect.get('MVR Class') is not None:

--- a/panels/profiles/README.md
+++ b/panels/profiles/README.md
@@ -4,4 +4,4 @@
 
 Local files management, import from Share and from local files
 
-NOTE: this module has been ported here from the "development" branch. It's structure has mostly been kept. 
+NOTE: this module has been ported here from the "development" branch. It's structure has mostly been kept.

--- a/panels/profiles/controller/manager.py
+++ b/panels/profiles/controller/manager.py
@@ -110,7 +110,7 @@ def queue_up(function, arg):
 
 
 def execute_queued_functions():
-    print("check")
+    print("INFO", "check")
     while not execution_queue.empty():
         items = execution_queue.get()
         execute = items[0]
@@ -125,8 +125,6 @@ def execute_queued_functions():
 
 
 def reload_share_profiles(result):
-    print("loading profiles")
-    print(result)
     if result.status:
         ShowMessageBox(
             _("Share index updated. Status code was: {}").format(result.result.status_code),
@@ -143,7 +141,6 @@ def reload_share_profiles(result):
 
 
 def reload_local_profiles(result):
-    print(result)
     DMX_GDTF.getManufacturerList()
     Profiles.DMX_Fixtures_Local_Profile.loadLocal()
     if result.status:

--- a/panels/profiles/data/share_profile.py
+++ b/panels/profiles/data/share_profile.py
@@ -67,7 +67,7 @@ class DMX_Fixtures_Import_Gdtf_Profile(PropertyGroup):
 
     @staticmethod
     def loadShare():
-        print("loading start")
+        print("INFO", "loading start")
         imports = bpy.context.window_manager.dmx.imports
         imports.share_profiles.clear()
         profiles = DMX_Fixtures_Import_Gdtf_Profile.get_profile_list()
@@ -88,4 +88,4 @@ class DMX_Fixtures_Import_Gdtf_Profile(PropertyGroup):
                 local_mode.name = mode["name"]
                 local_mode.footprint = mode["dmxfootprint"]
 
-        print("loading done")
+        print("INFO", "loading done")

--- a/share_api_client/__init__.py
+++ b/share_api_client/__init__.py
@@ -58,7 +58,7 @@ class GdtfShareApi:
     def make_call(self, slug=None, url_params="", method="GET", data={}):
         url = "%s/%s?%s" % (self.base_url, slug, url_params)
         if self.verbose:
-            print(url)
+            print("INFO", url)
         if method == "GET":
             # res = self.session.get(url, verify=False)
             res = self.session.get(url)
@@ -72,7 +72,7 @@ class GdtfShareApi:
 
     def get_list(self):
         result = self.make_call(method="GET", slug="getList.php")
-        print("result status", result, result.status)
+        print("INFO", "result status", result, result.status)
         if result.status:
             self.data = result.result.json()
             self.save_json_file(self.data.get("list", []), self.data_file)
@@ -87,7 +87,7 @@ class GdtfShareApi:
     def get_gdtf_files(self, data, file_path):
         for fixture in data:
             if self.verbose:
-                print(
+                print("INFO",
                     fixture.get("fixture"),
                     fixture.get("manufacturer"),
                     fixture.get("rid"),
@@ -97,7 +97,7 @@ class GdtfShareApi:
             res = self.make_call(slug="downloadFile.php", url_params=f"rid={fixture.get('rid')}")
             with open(os.path.join(file_path, filename), "wb") as out:
                 out.write(res.result.content)
-                print(f"saved {filename}")
+                print("INFO", f"saved {filename}")
         return res
 
 


### PR DESCRIPTION
Normally, the `pre-commit` is run after `git add <files>`, before running `git commit`, but one can also call `pre-commit run --all-files` to see issues with all files in the repo. This PR replaces some prints with logging and in some deeper places, harder to test, it adds "INFO", which is exempting print from being denied.