### PR TITLE
Set default texture percentage in 3ds importer to 100

### DIFF
--- a/gdtf.py
+++ b/gdtf.py
@@ -226,6 +226,7 @@ class DMX_GDTF:
     def loadModel(profile, model):
         current_path = os.path.dirname(os.path.realpath(__file__))
         extract_to_folder_path = os.path.join(current_path, "assets", "models", profile.fixture_type_id)
+        obj_dimension = Vector((model.length, model.width, model.height))
 
         if model.file.extension.lower() == "3ds":
             inside_zip_path = f"models/3ds/{model.file.name}.{model.file.extension}"
@@ -233,9 +234,8 @@ class DMX_GDTF:
             file_name = os.path.join(extract_to_folder_path, inside_zip_path)
             try:
                 load_3ds(file_name, bpy.context, FILTER={'MESH'}, KEYFRAME=False, APPLY_MATRIX=False)
-                obj_dimension = Vector((model.length, model.width, model.height))
                 for ob in bpy.context.selected_objects:
-                    if ob.dimensions.to_tuple(3) > obj_dimension.to_tuple(3):
+                    if ob.dimensions.to_tuple(3) > tuple(vec*10 for vec in obj_dimension.to_tuple(3)):
                         ob.data.transform(Matrix.Scale(0.001, 4))
             except Exception as e:
                 DMX_Log.log.error(f"Error loading a 3DS file {profile.name} {e}")

--- a/gdtf.py
+++ b/gdtf.py
@@ -262,11 +262,10 @@ class DMX_GDTF:
         if obj.dimensions.z <= 0:
             DMX_Log.log.error(f"Model {obj.name} Z size {obj.dimensions.z} <= 0. It will likely not work correctly.")
 
-        dim_x = obj.dimensions.x or 1
-        dim_y = obj.dimensions.y or 1
-        dim_z = obj.dimensions.z or 1
-
-        obj.scale = (obj.scale.x * model.length / dim_x, obj.scale.y * model.width / dim_y, obj.scale.z * model.height / dim_z)
+        obj.rotation_mode = 'XYZ'
+        scale_vector = obj.scale * obj_dimension
+        dimensions = obj.dimensions or Vector((1, 1, 1))
+        obj.scale = Vector([scale_vector[val] / dimensions[val] for val in range(3)])
         return obj
 
     @staticmethod

--- a/io_scene_3ds/import_3ds.py
+++ b/io_scene_3ds/import_3ds.py
@@ -516,7 +516,7 @@ def process_next_chunk(context, file, previous_chunk, imported_objects, CONSTRAI
         contextWrapper.use_nodes = True
         extend = 'wrap'
         alpha = False
-        pct = 70
+        pct = 100
 
         contextWrapper.base_color = contextColor[:]
         contextWrapper.metallic = contextMaterial.metallic


### PR DESCRIPTION
If the texture percentage chunk is missing in a 3ds file, the default should be 100 for a proper texture display

- io 3ds: Setted 3ds importer texture percentage default to 100
- gdtf: Changed to a more safe dimension check method
- gdtf: Use vector for dimensions calculation