### PR TITLE
gdtf: Apply transformation after joining the objects

### DIFF
--- a/gdtf.py
+++ b/gdtf.py
@@ -262,8 +262,7 @@ class DMX_GDTF:
         scale_vector = obj.scale * obj_dimension
         factor = Vector([scale_vector[val] / max(obj.dimensions[val], 1e-09) for val in range(3)])
         if model.file.extension.lower() == "3ds":
-            transformation = Matrix.Diagonal(factor).to_4x4()
-            obj.data.transform(transformation)
+            obj.data.transform(Matrix.Diagonal(factor).to_4x4())
         else:
             obj.scale = factor
         return obj

--- a/gdtf.py
+++ b/gdtf.py
@@ -260,8 +260,7 @@ class DMX_GDTF:
             DMX_Log.log.error(f"Model {obj.name} Z size {obj.dimensions.z} <= 0. It will likely not work correctly.")
 
         scale_vector = obj.scale * obj_dimension
-        dimensions = obj.dimensions or Vector((1, 1, 1))
-        factor = Vector([scale_vector[val] / max(dimensions[val], 1e-09) for val in range(3)])
+        factor = Vector([scale_vector[val] / max(obj.dimensions[val], 1e-09) for val in range(3)])
         if model.file.extension.lower() == "3ds":
             transformation = Matrix.Diagonal(factor).to_4x4()
             obj.data.transform(transformation)

--- a/gdtf.py
+++ b/gdtf.py
@@ -261,7 +261,7 @@ class DMX_GDTF:
 
         scale_vector = obj.scale * obj_dimension
         dimensions = obj.dimensions or Vector((1, 1, 1))
-        factor = Vector([scale_vector[val] / dimensions[val] for val in range(3)])
+        factor = Vector([scale_vector[val] / max(dimensions[val], 1e-09) for val in range(3)])
         if model.file.extension.lower() == "3ds":
             transformation = Matrix.Diagonal(factor).to_4x4()
             obj.data.transform(transformation)


### PR DESCRIPTION
After testing a plenty of gdtf, I found out that the scaling of geometries can have different factors and is not always 0.001 (this is only the case if they were exported from vectorworks), some have factor 0.01 or 0.1, resulting in wrong scaling. It is better to transform the meshes after joining the meshes of a 3ds file. Then calculate the correct factor. This will result in correct scale so it is not nessecary to set the scale again, this is now only nessecary for glb files.