### PR TITLE
Release v1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 ### Changelog
 
+### 1.7.5
+
+    * Allow using user writable directory associated with an extension (extension only)
+    * Show fixture name in Align panel if it is a selected active object
+    * Fix count of selected fixtures in Programmer, Align, and other panels
+    * Ensure that the beam has full diameter at the lense in Cycles for Blender 4.1 and up
+    * MVR import:
+        * Deselect all objects before import to prevent issues
+        * Add support for MVR classing to show/hide MVR classes
+    * GDTF import:
+        * Add constraints for multiple heads and yokes
+        * Apply transformation after joining the objects
+        * Check dimensions with safer method
+        * Allow import of existing files
+        * Use DMX break overwrite only for Geometry References
+        * Transfer root geometry attribute to children for complex fixtures
+        * Improved creating constraints and removed pixel factor
+    * Import_3ds: Fix texture color
+    * Increase time for collection auto-creation in import/export dialogs
+    * Update translatable language strings
+    * Add testing files download and basic testing scripts
+
+
 ### 1.7.4
 
     * Add Fixture Align and Distribute panel

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A DMX visualization tool inside <a href="https://blender.org">Blender</a>, desig
 
 First of all, make sure you have installed [Blender 3.4](https://www.blender.org/download/) or higher (Blender 4.x is supported). Then, download the `zip` file:
 
-### LATEST RELEASE (STABLE): v1.7.4
+### LATEST RELEASE (STABLE): v1.7.5
 
-   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.7.4.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.7.4/blenderDMX_v1.7.4.zip) file
+   1. From the [latest release](https://github.com/open-stage/blender-dmx/releases/latest) download the [blenderDMX_v1.7.5.zip](https://github.com/open-stage/blender-dmx/releases/download/v1.7.5/blenderDMX_v1.7.5.zip) file
 
 ### ROLLING RELEASE (UNSTABLE)
 

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 7, 4),
+    "version": (1, 7, 5),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",

--- a/in_gdtf.py
+++ b/in_gdtf.py
@@ -84,7 +84,7 @@ class DMX_OT_Import_GDTF(bpy.types.Operator, ImportHelper):
     def draw(self, context):
         dmx = context.scene.dmx
         if not dmx.collection:
-            Timer(0, createDMXcollection, ()).start()
+            Timer(0.5, createDMXcollection, ()).start()
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False

--- a/in_out_mvr.py
+++ b/in_out_mvr.py
@@ -38,7 +38,7 @@ class DMX_OT_Import_MVR(Operator, ImportHelper):
     def draw(self, context):
         dmx = context.scene.dmx
         if not dmx.collection:
-            Timer(0, createDMXcollection, ()).start()
+            Timer(0.5, createDMXcollection, ()).start()
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
@@ -66,7 +66,7 @@ class DMX_OT_Export_MVR(Operator, ExportHelper):
     def draw(self, context):
         dmx = context.scene.dmx
         if not dmx.collection:
-            Timer(0, createDMXcollection, ()).start()
+            Timer(0.5, createDMXcollection, ()).start()
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False


### PR DESCRIPTION
* Allow using user writable directory associated with an extension (extension only)
* Show fixture name in Align panel if it is a selected active object
* Fix count of selected fixtures in Programmer, Align, and other panels
* Ensure that the beam has full diameter at the lense in Cycles for Blender 4.1 and up
* MVR import:
    * Deselect all objects before import to prevent issues
    * Add support for MVR classing to show/hide MVR classes
* GDTF import:
    * Add constraints for multiple heads and yokes
    * Apply transformation after joining the objects
    * Check dimensions with safer method
    * Allow import of existing files
    * Use DMX break overwrite only for Geometry References
    * Transfer root geometry attribute to children for complex fixtures
    * Improved creating constraints and removed pixel factor
* Import_3ds: Fix texture color
* Increase time for collection auto-creation in import/export dialogs
* Update translatable language strings
* Add testing files download and basic testing scripts

