### PR TITLE
Add subfixtures based controllix

### DIFF
--- a/data.py
+++ b/data.py
@@ -104,7 +104,7 @@ class DMX_Data:
             return
 
         if DMX_Data._dmx is not None:
-            dmx = bpy.context.scene.dmx # hmm, here we use non cached dmx, probably this was safer...
+            dmx = bpy.context.scene.dmx  # hmm, here we use non cached dmx, probably this was safer...
             if dmx.get_selected_live_dmx_universe().input == "BLENDERDMX":
                 dmx = bpy.context.scene.dmx
                 dmx.dmx_values[addr - 1].channel = val
@@ -113,7 +113,7 @@ class DMX_Data:
 
         # LiveDMX view
         if DMX_Data._dmx is not None:
-            dmx = bpy.context.scene.dmx # ...or maybe it prevents using this call before the class is ready?
+            dmx = bpy.context.scene.dmx  # ...or maybe it prevents using this call before the class is ready?
             selected_live_dmx_universe = dmx.get_selected_live_dmx_universe()
             if selected_live_dmx_universe is None:  # this should not happen
                 raise ValueError("Missing selected universe, as if DMX base class is empty...")
@@ -121,14 +121,17 @@ class DMX_Data:
                 DMX_Data._live_view_data = DMX_Data._universes[universe]
 
     @staticmethod
-    def set_virtual(fixture, attribute, value):
+    def set_virtual(fixture, attribute, geometry, value):
         """Set value of virtual channel for given fixture"""
         DMX_Log.log.debug((fixture, attribute, value))
         if value > 255:
             return
         if fixture not in DMX_Data._virtuals:
             DMX_Data._virtuals[fixture] = {}
-        DMX_Data._virtuals[fixture][attribute] = value
+        if attribute not in DMX_Data._virtuals[fixture]:
+            DMX_Data._virtuals[fixture][attribute] = {}
+        DMX_Data._virtuals[fixture][attribute]["value"] = value
+        DMX_Data._virtuals[fixture][attribute]["geometry"] = geometry
 
     @staticmethod
     def get_virtual(fixture):

--- a/dmx.py
+++ b/dmx.py
@@ -59,6 +59,7 @@ from .panels import programmer as programmer
 from .panels import profiles as Profiles
 from .panels import distribute as distribute
 from .panels import classing as classing
+from .panels import subfixtures as subfixtures
 
 from .preferences import DMX_Preferences, DMX_Regenrate_UUID
 from .group import FixtureGroup, DMX_Group
@@ -117,7 +118,8 @@ class DMX(PropertyGroup):
                     DMX_MVR_Xchange_Client,
                     DMX_MVR_Xchange,
                     DMX_Regenrate_UUID,
-                    DMX_Preferences)
+                    DMX_Preferences,
+                    subfixtures.DMX_Subfixture)
 
     # Classes to be registered
     # The registration is done in two steps. The second only runs
@@ -167,6 +169,9 @@ class DMX(PropertyGroup):
                 groups.DMX_PT_Groups,
                 classing.DMX_UL_Class,
                 classing.DMX_PT_Classes,
+                subfixtures.DMX_PT_Subfixtures,
+                subfixtures.DMX_UL_Subfixture,
+                subfixtures.DMX_OT_Subfixture_Clear,
                 programmer.DMX_OT_Programmer_DeselectAll,
                 programmer.DMX_OT_Programmer_SelectAll,
                 programmer.DMX_OT_Programmer_SelectFiltered,

--- a/dmx_temp_data.py
+++ b/dmx_temp_data.py
@@ -19,6 +19,7 @@ import bpy
 
 from . import fixture as fixture
 from .logging import DMX_Log
+from .panels import subfixtures
 
 from .mvr_xchange import DMX_MVR_Xchange
 from .panels import profiles as Profiles
@@ -31,6 +32,7 @@ from bpy.props import (BoolProperty,
                        CollectionProperty)
 
 from bpy.types import (PropertyGroup)
+from .fixture import DMX_Fixture_Channel
 
 from .i18n import DMX_Lang
 _ = DMX_Lang._
@@ -129,3 +131,20 @@ class DMX_TempData(PropertyGroup):
     dist_gap: FloatProperty(name="Gap", default=2)
     dist_diameter: FloatProperty(name="Diameter", default=2)
     dist_rotate: BoolProperty(name="Rotate", default=False)
+    programmer_source: StringProperty(name="Source")
+
+    subfixtures: CollectionProperty(
+            name = _("Subfixtures"),
+            type=subfixtures.DMX_Subfixture
+            )
+
+    active_subfixtures: CollectionProperty(
+            name = _("Active Subfixtures"),
+            type=PropertyGroup
+            )
+
+    active_subfixture_i : IntProperty(
+        default = -1
+        )
+
+    selected_fixture_label: StringProperty()

--- a/fixture.py
+++ b/fixture.py
@@ -171,6 +171,14 @@ class DMX_Fixture(PropertyGroup):
         type = DMX_Fixture_Channel
     )
 
+    gdtf_long_name: StringProperty(
+        name = "Fixture > Name",
+        default = "")
+
+    gdtf_manufacturer: StringProperty(
+        name = "Fixture > Manufacturer",
+        default = "")
+
     def ensure_universe_exists(self, context):
         dmx = bpy.context.scene.dmx
         dmx.ensureUniverseExists(self.universe)
@@ -326,6 +334,8 @@ class DMX_Fixture(PropertyGroup):
 
         # Import and deep copy Fixture Model Collection
         gdtf_profile = DMX_GDTF.loadProfile(profile)
+        self.gdtf_long_name = gdtf_profile.long_name
+        self.gdtf_manufacturer = gdtf_profile.manufacturer
 
         # Handle if dmx mode doesn't exist (maybe this is MVR import and GDTF files were replaced)
         # use mode[0] as default

--- a/fixture.py
+++ b/fixture.py
@@ -1164,6 +1164,7 @@ class DMX_Fixture(PropertyGroup):
         else:
             geometry = self.get_object_by_geometry_name(geometry)
         if geometry:
+            geometry.rotation_mode = "XYZ"
             geometry.rotation_euler[offset] = value
             if current_frame and self.dmx_cache_dirty:
                 geometry.keyframe_insert(data_path="location", frame=current_frame)

--- a/panels/programmer.py
+++ b/panels/programmer.py
@@ -403,7 +403,19 @@ class DMX_PT_Programmer(Panel):
         elif len(selected_fixtures) == 1:
             selected_fixture_label = selected_fixtures[0].name
         else:
-            selected_fixture_label = _("{} selected").format(len(selected_fixtures))
+            profiles=[]
+            for sel_fixture in selected_fixtures:
+                if sel_fixture.gdtf_long_name:
+                    name = sel_fixture.gdtf_long_name
+                else:
+                    name = sel_fixture.profile.removesuffix(".gdtf")
+
+                profiles.append(f"{name}-{sel_fixture.mode}")
+            profiles = list(set(profiles))
+            if len(profiles)==1:
+                selected_fixture_label = f"{len(selected_fixtures)} {profiles[0]}"
+            else:
+                selected_fixture_label = _("{} selected").format(len(selected_fixtures))
 
         row = layout.row()
         row.operator("dmx.select_all", text="", icon="SELECT_EXTEND")

--- a/panels/subfixtures.py
+++ b/panels/subfixtures.py
@@ -1,0 +1,103 @@
+#    Copyright vanous
+#
+#    This file is part of BlenderDMX.
+#
+#    BlenderDMX is free software: you can redistribute it and/or modify it
+#    under the terms of the GNU General Public License as published by the Free
+#    Software Foundation, either version 3 of the License, or (at your option)
+#    any later version.
+#
+#    BlenderDMX is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+#    more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import bpy
+
+from bpy.types import Panel, Menu, Operator, UIList
+
+from bpy.props import BoolProperty, StringProperty, CollectionProperty
+
+from bpy.types import PropertyGroup
+from ..i18n import DMX_Lang
+
+_ = DMX_Lang._
+# List #
+
+
+class DMX_UL_Subfixture(UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            col = layout.column()
+            col.ui_units_x = 3
+            col = layout.column()
+            col.label(text=f"{item.name}")
+            col = layout.column()
+            col.prop(item, "enabled", text="")
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            layout.label(text=str(item.id), icon=icon)
+
+
+class DMX_OT_Subfixture_Clear(Operator):
+    bl_label = _("Clear selection")
+    bl_idname = "dmx.clear_subfixtures"
+    bl_description = _("Clear subfixture selection")
+    bl_options = {"UNDO"}
+
+    def execute(self, context):
+        temp_data = bpy.context.window_manager.dmx
+        #temp_data.active_subfixtures.clear()
+        for sf in temp_data.subfixtures:
+            sf.enabled=False
+        return {"FINISHED"}
+
+# Panel #
+
+
+class DMX_PT_Subfixtures(Panel):
+    bl_label = "Subfixtures"
+    bl_idname = "DMX_PT_Subfixtures"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "DMX"
+    bl_context = "objectmode"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        dmx = scene.dmx
+        temp_data = bpy.context.window_manager.dmx
+
+        layout.template_list("DMX_UL_Subfixture", "", temp_data, "subfixtures", temp_data, "active_subfixture_i", rows=4)
+
+        selected = ",".join([s.name for s in temp_data.active_subfixtures])
+        row = layout.row()
+        col1 = row.column()
+        if selected:
+            col1.label(text=f"Selected: {selected}")
+        col2 = row.column()
+        col2.operator("dmx.clear_subfixtures", icon="CHECKBOX_DEHLT", text="")
+
+class DMX_Subfixture(PropertyGroup):
+    name: StringProperty()
+
+    def onEnable(self, context):
+        enabled = self.enabled
+        temp_data = bpy.context.window_manager.dmx
+
+        if enabled:
+            if self.name not in temp_data.active_subfixtures:
+                temp_data.active_subfixtures.add().name = self.name
+        else:
+            if self.name in temp_data.active_subfixtures:
+                for index, item in enumerate(temp_data.active_subfixtures):
+                    if item.name == self.name:
+                        temp_data.active_subfixtures.remove(index)
+                        break
+
+    enabled: BoolProperty(update=onEnable, default=False)


### PR DESCRIPTION
This allows to control more complex fixtures directly without external desk.
The Programmer is built dynamically based on attributes which are supported by selected geometries (called subfixtures in this case).
Each "subfixture" is "just" the currently selected geometry (in the Subfixtures list, not in the 3D). As one can select more then one subfixture, there is no need to try to glue multiple geometries together based on unique attributes.