### PR TITLE
Release addon 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Changelog
 
+### 1.8.0
+
+* Updated translations
+* Add support for pan/tilt rotation, add GDTF fixture with continuous rotation
+* Add support for CTC
+* Add display device label also in 3D
+* Add subfixture based controlling
+* Programmer: show fixture type name if multiple selection is one gdtf type
+* Fix: Ensure working Pan/tilt control for fixtures without target
+* Fix: Fix keyframe cleaning after addition of PSN
+* Fix: Adjust share profile path after changes for custom user data path
+* Fix: Ensure that World - Scene - Background exists
+
 ### 1.7.5
 
     * Allow using user writable directory associated with an extension (extension only)

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ bl_info = {
     "name": "DMX",
     "description": "DMX visualization and programming, with GDTF/MVR and Network support",
     "author": "open-stage",
-    "version": (1, 7, 5),
+    "version": (1, 8, 0),
     "blender": (3, 4, 0),
     "location": "3D View > DMX",
     "doc_url": "https://blenderdmx.eu/docs/faq/",


### PR DESCRIPTION
The Addon version does not include support for Gobo2 and for Iris.

* Updated translations
* Add support for pan/tilt rotation, add GDTF fixture with continuous rotation
* Add support for CTC
* Add display device label also in 3D
* Add subfixture based controlling
* Programmer: show fixture type name if multiple selection is one gdtf type
* Fix: Ensure working Pan/tilt control for fixtures without target
* Fix: Fix keyframe cleaning after addition of PSN
* Fix: Adjust share profile path after changes for custom user data path
* Fix: Ensure that World - Scene - Background exists
