### PR TITLE
Release v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 ### Changelog
 
+### 1.8.3
+
+* MVR-xchange networking working also on Windows:
+    * Tweak networking to get port number on Windows hosts
+    * List only MVR-xchange clients with at least minimal required data
+    * Do not allow empty mDNS service group
+    * Add network interface selection
+
 ### 1.8.2
 
 * Update pygdtf to pygdtf-1.0.5.dev8
 * Translated using Weblate:
-    * (Czech) (origin/main, origin/HEAD) [vanous]
+    * (Czech) [vanous]
     * (Italian) [Fede Pre]
     * (Tamil) [தமிழ்நேரம்]
     * (Chinese (Simplified Han script)) [大学没毕业]

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,12 +1,12 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "1.8.2"
+version = "1.8.3"
 name = "DMX"
 tagline = "DMX visualization and programming with GDTF/MVR, and Networking"
 maintainer = "Open Stage"
 type = "add-on"
 website = "https://blenderdmx.eu/"
-tags = ["Lighting", "Animation"]
+tags = ["Lighting", "Animation", "Scene", "Import-Export", "Rigging", "Tracking", "Sequencer", "3D View", "Camera"]
 blender_version_min = "4.2.0"
 
 license = [


### PR DESCRIPTION
### 1.8.3

* MVR-xchange networking working also on Windows:
    * Tweak networking to get port number on Windows hosts
    * List only MVR-xchange clients with at least minimal required data
    * Do not allow empty mDNS service group
    * Add network interface selection
