### PR TITLE
Fix an `IndexError` when creating fixtures on some systems

### DIFF
--- a/gdtf.py
+++ b/gdtf.py
@@ -218,12 +218,14 @@ class DMX_GDTF:
             # default 2D
             extract_to_folder_path = DMX_GDTF.getPrimitivesPath()
             filename = "thumbnail.svg"
+
+        filepath = os.path.join(extract_to_folder_path, filename)
         try:
-            bpy.ops.wm.grease_pencil_import_svg(filepath=extract_to_folder_path, directory=extract_to_folder_path, files=[{"name": filename}], scale=1)
+            bpy.ops.wm.grease_pencil_import_svg(filepath=filepath, scale=1)
         except Exception as e:
             print(e)
         try:
-            bpy.ops.wm.gpencil_import_svg(filepath=extract_to_folder_path, directory=extract_to_folder_path, files=[{"name": filename}], scale=1)
+            bpy.ops.wm.gpencil_import_svg(filepath=filepath, scale=1)
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
This PR changes how the 2d thumbnails are loaded into the scene.

Looking at the current implementation, and the git line history, it seems that there is no particular reason (previous bugfix, etc.) why the line provided the file name in the files array rather than just as the file path, when the array only gave one file anyway!

By loading it in the previous way, it ended up creating two objects on some systems, one called "primitives" (which is the last part of the path given to `filepath`), and one which was the thumbnail itself. It then moved `primitive` in as the 2D thumbnail, which had no data and therefore no material, causing a crash.

With thanks to b48g55m on the Discord who helped find the source of this problem.