### PR TITLE
Add CI action to check format with ruff, reformat all code

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,13 @@
+name: Check if code is formatted
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v1
+        with:
+          args: --version
+      - uses: astral-sh/ruff-action@v1
+        with:
+          args: format --check


### PR DESCRIPTION
This adds CI action to check if all code is formatted with ruff.
Exceptions to ruff can be disabled for blocks with 
\# fmt: off
code ignored from formatting
\# fmt: on
