### PR TITLE
Add per file application UUID, make hostname in mDNS service optional

### DIFF
--- a/blender_utils.py
+++ b/blender_utils.py
@@ -59,13 +59,6 @@ def version_compare(current_version, new_version):
     return 0
 
 
-def get_latest_release(callback, context):
-    url = "https://api.github.com/repos/open-stage/blender-dmx/releases/latest"
-    thread = threading.Thread(target=get_version_json, args=(url, callback, context))
-    thread.start()
-    thread.join()
-
-
 def export_custom_data(directory_name, file_name):
     dmx = bpy.context.scene.dmx
     folder_path = dmx.get_addon_path()

--- a/dmx.py
+++ b/dmx.py
@@ -1401,6 +1401,12 @@ class DMX(PropertyGroup):
 
     mvr_x_ws_url: StringProperty(name="URL", description="URL", default="")
 
+    mvrx_hostname_in_service : BoolProperty(
+        name = _("Add hostname to MVR-xchange service"),
+        description=_("Add computer name as sub-sub service in mDNS"),
+        default = False,
+    )
+
     # # DMX > ArtNet > Status
 
     artnet_status : EnumProperty(

--- a/dmx.py
+++ b/dmx.py
@@ -239,7 +239,6 @@ class DMX(PropertyGroup):
         fixtures.DMX_OT_Fixture_SelectPrevious,
         fixtures.DMX_OT_Fixture_SelectNextTarget,
         fixtures.DMX_OT_Fixture_SelectPreviousTarget,
-        setup.DMX_OT_VersionCheck,
         programmer.DMX_PT_Programmer,
         recorder.DMX_OT_Recorder_AddKeyframe,
         recorder.DMX_PT_Recorder,
@@ -626,12 +625,6 @@ class DMX(PropertyGroup):
         self.check_python_version()
         self.check_blender_version()
         self.print_extension_version()
-
-        if bpy.app.version >= (4, 2):
-            # do not do version check online in 4.2 and up
-            pass
-        else:
-            Timer(1, bpy.ops.dmx.check_version, ()).start()
 
         DMX_GDTF.getManufacturerList()
         Profiles.DMX_Fixtures_Local_Profile.loadLocal()

--- a/dmx.py
+++ b/dmx.py
@@ -532,6 +532,7 @@ class DMX(PropertyGroup):
 
         # Create a DMX universe
         self.addUniverse()
+        self.generate_project_uuid()
 
         # Link addon to file
         self.linkFile()
@@ -1385,6 +1386,12 @@ class DMX(PropertyGroup):
         update = onZeroconfEnableDiscovery
     )
 
+    project_application_uuid: StringProperty(
+        default=str(py_uuid.uuid4()),
+        name="Per project application UUID",
+        description="Used for example for MVR xchange",
+    )
+
     mvrx_enabled : BoolProperty(
         name = _("Connect to a selected station"),
         description=_("Connects to an MVR-xchange station"),
@@ -1407,6 +1414,11 @@ class DMX(PropertyGroup):
         default = False,
     )
 
+    mvrx_per_project_station_uuid : BoolProperty(
+        name = _("Use per-project Station UUID"),
+        description=_("Generates a random UUID for every blend file"),
+        default = True,
+    )
     # # DMX > ArtNet > Status
 
     artnet_status : EnumProperty(
@@ -2271,6 +2283,9 @@ class DMX(PropertyGroup):
 
     def removeUniverse(self, i):
         DMX_Universe.remove(self, i)
+
+    def generate_project_uuid(self):
+        self.project_application_uuid = str(py_uuid.uuid4())
 
     # # Render
 

--- a/mdns.py
+++ b/mdns.py
@@ -49,6 +49,8 @@ class DMX_Zeroconf:
         application_uuid = prefs.get(
             "application_uuid", str(pyuuid.uuid4())
         )  # must never be 0
+        if self._dmx.mvrx_per_project_station_uuid:
+            application_uuid = self._dmx.project_application_uuid
         self.application_uuid = application_uuid
 
     def callback(

--- a/mdns.py
+++ b/mdns.py
@@ -143,10 +143,17 @@ class DMX_Zeroconf:
 
         ip_address = bpy.context.window_manager.dmx.mvr_xchange.ip_address
         addrs = [socket.inet_pton(socket.AF_INET, ip_address)]
+        DMX_Log.log.debug(addrs)
+
+        dmx = bpy.context.scene.dmx
+        if dmx.mvrx_hostname_in_service:
+            service_name = f"{station_name.replace(' ', '_')}.{server_name}._mvrxchange._tcp.local."
+        else:
+            service_name = f"{server_name}._mvrxchange._tcp.local."
 
         DMX_Zeroconf._instance.info = ServiceInfo(
             "_mvrxchange._tcp.local.",
-            name=f"{station_name.replace(' ', '_')}.{server_name}._mvrxchange._tcp.local.",
+            name=service_name,
             addresses=addrs,
             port=port,
             properties=desc,

--- a/mvrx_protocol.py
+++ b/mvrx_protocol.py
@@ -50,6 +50,9 @@ class DMX_MVR_X_Client:
         application_uuid = prefs.get(
             "application_uuid", str(py_uuid.uuid4())
         )  # must never be 0
+        if self._dmx.mvrx_per_project_station_uuid:
+            application_uuid = self._dmx.project_application_uuid
+
         self.application_uuid = application_uuid
         # print("bl info", application_info) # TODO: use this in the future
 
@@ -225,6 +228,8 @@ class DMX_MVR_X_Server:
         application_uuid = prefs.get(
             "application_uuid", str(py_uuid.uuid4())
         )  # must never be 0
+        if self._dmx.mvrx_per_project_station_uuid:
+            application_uuid = self._dmx.project_application_uuid
         self.application_uuid = application_uuid
         # print("bl info", application_info) # TODO: use this in the future
 
@@ -299,6 +304,8 @@ class DMX_MVR_X_WS_Client:
         application_uuid = prefs.get(
             "application_uuid", str(py_uuid.uuid4())
         )  # must never be 0
+        if self._dmx.mvrx_per_project_station_uuid:
+            application_uuid = self._dmx.project_application_uuid
         self.application_uuid = application_uuid
         # print("bl info", application_info) # TODO: use this in the future
 

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -206,8 +206,8 @@ class DMX_PT_Setup_Volume(Panel):
         dmx = context.scene.dmx
 
         box = layout.column().box()
-        box.prop(context.scene.dmx, "volume_preview")
-        box.prop(context.scene.dmx, "disable_overlays")
+        box.prop(dmx, "volume_preview")
+        box.prop(dmx, "disable_overlays")
 
         box = layout.column().box()
         box.operator(
@@ -217,13 +217,13 @@ class DMX_PT_Setup_Volume(Panel):
         )
 
         row = box.row()
-        row.prop(context.scene.dmx, "volume_enabled")
+        row.prop(dmx, "volume_enabled")
         row.enabled = dmx.volume is not None
 
         row_den = box.row()
-        row_den.prop(context.scene.dmx, "volume_density")
+        row_den.prop(dmx, "volume_density")
         row_scale = box.row()
-        row_scale.prop(context.scene.dmx, "volume_noise_scale")
+        row_scale.prop(dmx, "volume_noise_scale")
         row_den.enabled = row_scale.enabled = dmx.volume is not None
 
         selected = dmx.selectedFixtures()
@@ -231,12 +231,12 @@ class DMX_PT_Setup_Volume(Panel):
 
         row = box.row()
         col1 = row.column()
-        col1.prop(context.scene.dmx, "beam_intensity_multiplier")
+        col1.prop(dmx, "beam_intensity_multiplier")
 
         box = layout.column().box()
         row = box.row()
         col1 = row.column()
-        col1.prop(context.scene.dmx, "reduced_beam_diameter_in_cycles")
+        col1.prop(dmx, "reduced_beam_diameter_in_cycles")
         col2 = row.column()
         col2.operator(
             "wm.url_open", text="", icon="HELP"
@@ -276,20 +276,20 @@ class DMX_PT_Setup_Viewport(Panel):
         row = layout.row()
         row.label(text=_("Background Color"))
         row = layout.row()
-        row.prop(context.scene.dmx, "background_color", text="")
+        row.prop(dmx, "background_color", text="")
         row = layout.row()
         row.prop(context.window_manager.dmx, "pause_render")
         row = layout.row()
-        row.prop(context.scene.dmx, "display_2D")
+        row.prop(dmx, "display_2D")
         row = layout.row()
-        row.prop(context.scene.dmx, "enable_device_label")
+        row.prop(dmx, "enable_device_label")
         row = layout.row()
-        row.prop(context.scene.dmx, "display_device_label")
+        row.prop(dmx, "display_device_label")
         row.enabled = dmx.display_2D or dmx.enable_device_label
         row = layout.row()
-        row.prop(context.scene.dmx, "display_pigtails")
+        row.prop(dmx, "display_pigtails")
         row = layout.row()
-        row.prop(context.scene.dmx, "select_geometries")
+        row.prop(dmx, "select_geometries")
 
 
 class DMX_PT_Setup_Extras(Panel):
@@ -306,26 +306,6 @@ class DMX_PT_Setup_Extras(Panel):
         layout = self.layout
         dmx = context.scene.dmx
         old_data_exists = blender_utils.old_custom_data_exists()
-        if bpy.app.version >= (4, 2):
-            # do not do version check online in 4.2 and up
-            pass
-        else:
-            layout.operator(
-                "dmx.check_version",
-                text=_("Check for BlenderDMX updates"),
-                icon="SHADING_WIRE",
-            )
-            row = layout.row()
-            col1 = row.column()
-            col1.label(
-                text=_("Status: {}").format(
-                    context.window_manager.dmx.release_version_status
-                )
-            )
-            col2 = row.column()
-            col2.operator(
-                "wm.url_open", text="", icon="SHADING_WIRE"
-            ).url = "https://github.com/open-stage/blender-dmx/releases/latest"
         row = layout.row()
         row.operator_context = "INVOKE_DEFAULT"  #'INVOKE_AREA'
         row.operator(
@@ -431,7 +411,7 @@ class DMX_PT_Setup_Logging(Panel):
         dmx = context.scene.dmx
         layout = self.layout
         row = layout.row()
-        row.prop(context.scene.dmx, "logging_level")
+        row.prop(dmx, "logging_level")
         row = layout.row()
         row.label(text=_("Log filter"))
         row = layout.row(align=True)
@@ -473,50 +453,10 @@ class DMX_PT_Setup(Panel):
                 layout.label(
                     text=_("Error! Blender 3.4 or higher required."), icon="ERROR"
                 )
-            # if bpy.app.version >= (4, 2):
-            #    row = layout.row()
-            #    row.label(text=_("For Blender 4.2 and up use the Extension"), icon="ERROR")
-            #    row.operator("wm.url_open", text="BlenderDMX Extension", icon="SHADING_WIRE").url = "https://extensions.blender.org/add-ons/open-stage-blender-dmx/"
             layout.operator("dmx.new_show", text=_("Create New Show"), icon="LIGHT")
             layout.operator(
                 "wm.url_open", text="User Guide Online", icon="HELP"
             ).url = "https://blenderdmx.eu/docs/faq/"
-
-
-class DMX_OT_VersionCheck(Operator):
-    bl_label = _("Check version")
-    bl_description = _("Check if there is new release of BlenderDMX")
-    bl_idname = "dmx.check_version"
-    bl_options = {"UNDO"}
-
-    def callback(self, data, context):
-        temp_data = context.window_manager.dmx
-        text = _("Unknown version error")
-        if "error" in data:
-            text = data["error"]
-        else:
-            try:
-                current_version = blender_utils.get_application_version()
-                new_version = data["name"]
-                res = blender_utils.version_compare(current_version, new_version)
-            except Exception as e:
-                text = f"{e.__class__.__name__} {e}"
-            else:
-                if res < 0:
-                    text = _("New version {} available").format(new_version)
-                elif res > 0:
-                    text = _("You are using pre-release version")
-                else:
-                    text = _("You are using latest version of BlenderDMX")
-
-        self.report({"INFO"}, f"{text}")
-        temp_data.release_version_status = text
-
-    def execute(self, context):
-        temp_data = context.window_manager.dmx
-        temp_data.release_version_status = _("Checking...")
-        blender_utils.get_latest_release(self.callback, context)
-        return {"FINISHED"}
 
 
 class DMX_OT_Import_Custom_Data(Operator):

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -324,6 +324,8 @@ class DMX_PT_Setup_Extras(Panel):
         layout.operator(
             "wm.url_open", text="User Guide Online", icon="HELP"
         ).url = "https://blenderdmx.eu/docs/faq/"
+        row = layout.row()
+        row.prop(dmx, "mvrx_hostname_in_service")
 
 
 class DMX_PT_Setup_Import(Panel):

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -326,6 +326,8 @@ class DMX_PT_Setup_Extras(Panel):
         ).url = "https://blenderdmx.eu/docs/faq/"
         row = layout.row()
         row.prop(dmx, "mvrx_hostname_in_service")
+        row = layout.row()
+        row.prop(dmx, "mvrx_per_project_station_uuid")
 
 
 class DMX_PT_Setup_Import(Panel):


### PR DESCRIPTION
- remove old online version check
- make application uuid to be (optionally, enabled by default) per blend file
- add option (disabled by default) to add hostname to sub-sub service in mDNS