### PR TITLE
Shutter/dimmer as keyframable physical values. Zoom intensity compensation.

### DIFF
--- a/dmx.py
+++ b/dmx.py
@@ -2422,6 +2422,8 @@ class DMX(PropertyGroup):
             ["CTB", 2700, 12000],
             ["CT0", 2700, 12000],
             ["Iris", 0, 1],
+            ["Shutter1", 0, 1],
+            ["Shutter1Strobe", 0.3, 20],
         ]
         for default in defaults:
             new_function = self.default_channel_functions.add()


### PR DESCRIPTION
This PR redoes the dimmer/shutter to use physical values from channel functions.
The older timer base strobe has been replaced by driver, this means the animation player must be playing for this to be shown.
Keyframing is still somewhat of an issue as Blender doesn't like to pre-calculate the light power, but one can do autokeyframing and keep moving the dimmer, to store the strobing.

This PR also adds light intensity compensation when zooming, to address this issue https://github.com/open-stage/blender-dmx/issues/7 . There is room for improvements, as always.
