### PR TITLE
Apply geometry offset

### DIFF
--- a/fixture.py
+++ b/fixture.py
@@ -2166,6 +2166,7 @@ class DMX_Fixture(PropertyGroup):
         else:
             geometry = self.get_object_by_geometry_name(geometry)
         if geometry:
+            value = value + geometry.get("applied_rotation", [0, 0])[offset]
             geometry.rotation_mode = "XYZ"
             geometry.rotation_euler[offset] = value
             if current_frame and self.dmx_cache_dirty:

--- a/gdtf.py
+++ b/gdtf.py
@@ -635,6 +635,9 @@ class DMX_GDTF:
             rotation = geometry_mtx.to_3x3().inverted()
             scale = geometry_mtx.to_scale()
             obj_child.matrix_local = Matrix.LocRotScale(translate, rotation, scale)
+            obj_child.rotation_mode = "XYZ"
+            obj_child["applied_rotation"] = obj_child.rotation_euler
+            # baking into the object did not work, we store the rotation and re-apply it on pan/tilt in render()
 
         def constraint_child_to_parent(parent_geometry, child_geometry):
             if sanitize_obj_name(parent_geometry) not in objs:


### PR DESCRIPTION
If a moving geometry has a defined offset, we need to ensure that pan/tilt include the offset