### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 ### Changelog
 
-### NEXT
+### 2.0.1
 
 * Improve migration from older blend files
 * Unify programmer defaults
 * Fix gobo indexing angle calculation
-* Update packaged fixture profiles
+* Update packaged fixture profiles:
+    - keep only BlenderDMX created profiles
+    - improve the default profiles with more data
+    - provide RGBW/RGBA versions
+    - REMOVED some files like rotating beam or source4, they exist in the GDTF
+      Share
 * Add per-channel caching to render()
 * Save and apply XML provided offset to pan/tilt geometrie
 * Map pan, tilt, color picker to DMX RGB/CMY correctly and without drifting

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.0.0"
+version = "2.0.1"
 name = "DMX"
 tagline = "DMX visualization and programming with GDTF/MVR, and Networking"
 maintainer = "Open Stage"
@@ -51,5 +51,13 @@ paths_exclude_pattern = [
   "DEPENDENCIES.md",
   "DEVELOPMENT.md",
   "pyproject.toml",
+  "licenserc.toml",
+  "gpl-header.txt",
+  "uv.lock",
+  "i18n/update.sh",
+  "i18n/__pycache__/",
+  "i18n/readme-i18n.txt",
+  "i18n/babel.cfg",
+  "i18n/messages.pot",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "0.1.0"
+version = "2.0.1"
 description = ""
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
### 2.0.1

* Improve migration from older blend files
* Unify programmer defaults
* Fix gobo indexing angle calculation
* Update packaged fixture profiles:
    - keep only BlenderDMX created profiles
    - improve the default profiles with more data
    - provide RGBW/RGBA versions
    - REMOVED some files like rotating beam or source4, they exist in the GDTF
      Share
* Add per-channel caching to render()
* Save and apply XML provided offset to pan/tilt geometrie
* Map pan, tilt, color picker to DMX RGB/CMY correctly and without drifting
