### PR TITLE
Release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Changelog
 
+### 2.0.2
+
+* Update pygdtf to 1.2.4
+* Sync Shutter1Strobe to the programmer
+* Make Shutter1Strobe flashing, not pulsing
+* Ensure that DMX breaks's address/universe are overflowing 512
+* Export MVR with breaks from 0, set universe 0 as 1
+* Fix programmer values after clear
+* Clear any selection prior to fixture edit/mvr import
+* Add option to not modify Fixture_ID and Address during Edit
+* Ensure that color defined close to GDTF default white is interpreted as full white
+* Remove and re-copy BlenderDMX provided files when Cleaning project data
+
 ### 2.0.1
 
 * Improve migration from older blend files

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.0.1"
+version = "2.0.2"
 name = "DMX"
 tagline = "DMX visualization and programming with GDTF/MVR, and Networking"
 maintainer = "Open Stage"


### PR DESCRIPTION
* Update pygdtf to 1.2.4
* Sync Shutter1Strobe to the programmer
* Make Shutter1Strobe flashing, not pulsing
* Ensure that DMX breaks's address/universe are overflowing 512
* Export MVR with breaks from 0, set universe 0 as 1
* Fix programmer values after clear
* Clear any selection prior to fixture edit/mvr import
* Add option to not modify Fixture_ID and Address during Edit
* Ensure that color defined close to GDTF default white is interpreted as full white
* Remove and re-copy BlenderDMX provided files when Cleaning project data