### PR TITLE
Release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+### 2.0.3
+
+* Add initial support for DMX controlled bulb light like devices
+* Use model of geometry reference if provided
+* Update pygdtf to 1.2.5
+
 ### 2.0.2
 
 * Update pygdtf to 1.2.4

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.0.2"
+version = "2.0.3"
 name = "DMX"
 tagline = "DMX visualization and programming with GDTF/MVR, and Networking"
 maintainer = "Open Stage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "2.0.1"
+version = "2.0.3"
 description = ""
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
* Add initial support for DMX controlled bulb light like devices
* Use model of geometry reference if provided
* Update pygdtf to 1.2.5
  * Handle parsing of incorrect DmxValue values
  * Return default FixtureType if ElementTree.fromstring fails on malformed XML
