### PR TITLE
WIP: MVR-xchange multistation

### DIFF
--- a/mdns.py
+++ b/mdns.py
@@ -88,15 +88,19 @@ class DMX_Zeroconf:
                     station_uuid = info.properties[b"StationUUID"].decode("utf-8")
         station_name = f"{station_name} ({service_name})"
         DMX_Log.log.info(info)
+        # TODO: we should perhaps check if the station really has StationName
+        # and StationUUID before we add it into the list
         if state_change is ServiceStateChange.Added:
             DMX_Zeroconf._instance._dmx.createMVR_Client(
-                station_name, station_uuid, service_name, ip_address, int(port)
+                station_uuid, station_name, service_name, ip_address, int(port)
             )
         elif state_change is ServiceStateChange.Updated:
             DMX_Zeroconf._instance._dmx.updateMVR_Client(
                 station_uuid, station_name, service_name, ip_address, int(port)
             )
-        else:  # removed
+        elif state_change is ServiceStateChange.Removed:
+            # TODO: this typically does NOT work, because the info is empty. mDNS does not
+            # provide us with this info, but in some strange cases it actually works.
             DMX_Zeroconf._instance._dmx.removeMVR_Client(
                 station_uuid, station_name, service_name, ip_address, int(port)
             )
@@ -119,26 +123,24 @@ class DMX_Zeroconf:
             if DMX_Zeroconf._instance.browser:
                 DMX_Zeroconf._instance.browser.cancel()
                 DMX_Log.log.info("closing mvrx discovery")
-            if DMX_Zeroconf._instance.info:
-                DMX_Zeroconf._instance.zeroconf.unregister_service(
-                    DMX_Zeroconf._instance.info
-                )
+            # if DMX_Zeroconf._instance.info:
+            #    DMX_Zeroconf._instance.zeroconf.unregister_service(
+            #        DMX_Zeroconf._instance.info
+            #    )
             DMX_Zeroconf._instance.zeroconf.close()
             DMX_Zeroconf._instance = None
 
     @staticmethod
-    def enable_server(server_name=None, port=9999):
-        service_type = "_mvrxchange._tcp.local."
-        host_name = f"{socket.gethostname()}-{pyuuid.uuid4().hex}"
-        station_name = f"{defined_station_name} {socket.gethostname()}".replace(
-            " ", "_"
-        )
-
-        if server_name is None or server_name == "":
-            server_name = station_name
-
+    def enable_server(group_name=None, port=9999):
         if not DMX_Zeroconf._instance:
             DMX_Zeroconf._instance = DMX_Zeroconf()
+
+        dmx = bpy.context.scene.dmx
+        service_type = "_mvrxchange._tcp.local."
+        station_name = defined_station_name
+
+        if group_name is None or group_name == "":
+            group_name = station_name
 
         desc = {
             "StationUUID": DMX_Zeroconf._instance.application_uuid,
@@ -149,13 +151,7 @@ class DMX_Zeroconf:
         addrs = [socket.inet_pton(socket.AF_INET, ip_address)]
         DMX_Log.log.debug(addrs)
 
-        dmx = bpy.context.scene.dmx
-        if dmx.mvrx_hostname_in_service:
-            service_name = (
-                f"{station_name.replace(' ', '_')}.{server_name}.{service_type}"
-            )
-        else:
-            service_name = f"{server_name}.{service_type}"
+        service_name = f"{group_name}.{service_type}"
 
         DMX_Zeroconf._instance.info = ServiceInfo(
             service_type,
@@ -163,7 +159,7 @@ class DMX_Zeroconf:
             addresses=addrs,
             port=port,
             properties=desc,
-            server=f"{station_name.replace(' ', '_')}.{server_name}.{service_type}",
+            server=f"{station_name}.{group_name}.{service_type}",
         )
         DMX_Log.log.debug(DMX_Zeroconf._instance.info)
 

--- a/mvrx_protocol.py
+++ b/mvrx_protocol.py
@@ -56,22 +56,21 @@ class DMX_MVR_X_Client:
     @staticmethod
     def tcp_client_callback(data):
         # TODO: rework this from a keyword based parsing to message Type based parsing
+        dmx = bpy.context.scene.dmx
 
         station_uuid = ""
         if "StationUUID" in data:
             station_uuid = data["StationUUID"]
 
         if "Commits" in data and station_uuid != "":
-            DMX_MVR_X_Client._instance._dmx.createMVR_Commits(
-                data["Commits"], station_uuid
-            )
+            dmx.createMVR_Commits(data["Commits"], station_uuid)
 
         if "Type" in data and station_uuid != "":
             if data["Type"] == "MVR_COMMIT":
-                DMX_MVR_X_Client._instance._dmx.createMVR_Commits([data], station_uuid)
+                dmx.createMVR_Commits([data], station_uuid)
 
         if "FileUUID" in data and station_uuid != "":
-            DMX_MVR_X_Client._instance._dmx.createMVR_Commits([data], station_uuid)
+            dmx.createMVR_Commits([data], station_uuid)
 
         if "Provider" in data and station_uuid != "":
             provider = data["Provider"]
@@ -79,35 +78,36 @@ class DMX_MVR_X_Client:
 
             if "StationName" in data:
                 station_name = data["StationName"]
-            DMX_MVR_X_Client._instance._dmx.updateMVR_Client(
+            dmx.updateMVR_Client(
                 provider=provider, station_uuid=station_uuid, station_name=station_name
             )
 
         if "file_downloaded" in data:
-            DMX_MVR_X_Client._instance._dmx.fetched_mvr_downloaded_file(
-                data["file_downloaded"]
-            )
+            dmx.fetched_mvr_downloaded_file(data["file_downloaded"])
 
         msg_type = data.get("Type", "")
         msg_ok = data.get("OK", "")
         # msg_message = data.get("Message", "")
-        dmx = bpy.context.scene.dmx
         if msg_type == "MVR_JOIN_RET" and msg_ok is False:
             DMX_Log.log.error("MVR-xchange client refused our connection")
-            dmx.mvrx_enabled = False
+            dmx.toggle_join_MVR_Client(station_uuid, False)
 
         if msg_type == "MVR_REQUEST_RET" and msg_ok is False:
             DMX_Log.log.error("MVR-xchange file request declined")
             commit = DMX_MVR_X_Client._instance.client.commit
+            # TODO: this can create a race as the instance is now
+            # short lived. Perhaps we need to store the commit
+            # info in some other place
             if commit:
                 dmx.request_failed_mvr_downloaded_file(commit)
 
     @staticmethod
-    def create_self_request_commit(mvr_commit):
+    def create_self_request_commit(client, mvr_commit):
         """used when requesting commit ourselves just by mvr_request"""
+        dmx = bpy.context.scene.dmx
         uuid = mvr_commit["FileUUID"]
         station_uuid = mvr_commit["StationUUID"]
-        DMX_MVR_X_Client._instance._dmx.createMVR_Commits([mvr_commit], station_uuid)
+        dmx.createMVR_Commits([mvr_commit], station_uuid)
         clients = bpy.context.window_manager.dmx.mvr_xchange.mvr_xchange_clients
 
         for client in clients:
@@ -118,52 +118,38 @@ class DMX_MVR_X_Client:
                         return mvr_commit
 
     @staticmethod
-    def request_file(commit):
-        if not DMX_MVR_X_Client._instance:
+    def request_file(client, commit):
+        time.sleep(0.3)
+        DMX_MVR_X_Client.disable()
+        DMX_MVR_X_Client._instance = DMX_MVR_X_Client()
+        DMX_MVR_X_Client._instance.selected_client = client
+        DMX_MVR_X_Client.connect()
+        dmx = bpy.context.scene.dmx
+        ADDON_PATH = dmx.get_addon_path()
+        path = os.path.join(
+            ADDON_PATH, "assets", "mvrs", f"{commit.commit_uuid.upper()}.mvr"
+        )
+        DMX_Log.log.debug(f"path {path}")
+        try:
+            DMX_MVR_X_Client._instance.client.request_file(commit, path)
+        except Exception as e:
+            DMX_Log.log.debug(f"problem requesting file {e}")
             return
-        if DMX_MVR_X_Client._instance.client:
-            dmx = bpy.context.scene.dmx
-            ADDON_PATH = dmx.get_addon_path()
-            path = os.path.join(
-                ADDON_PATH, "assets", "mvrs", f"{commit.commit_uuid.upper()}.mvr"
-            )
-            DMX_Log.log.debug(f"path {path}")
-            try:
-                if not DMX_MVR_X_Client._instance.client.running:
-                    DMX_MVR_X_Client.connect()
-                DMX_MVR_X_Client._instance.client.request_file(commit, path)
-            except Exception as e:
-                DMX_Log.log.debug(f"problem requesting file {e}")
-                return
-            DMX_Log.log.info("Requesting file")
+        DMX_Log.log.info("Requesting file")
 
     @staticmethod
-    def send_commit(commit):
-        if not DMX_MVR_X_Client._instance:
-            return
-        if DMX_MVR_X_Client._instance.client:
-            try:
-                DMX_Log.log.debug("re-joining")
-                if not DMX_MVR_X_Client._instance.client.running:
-                    DMX_MVR_X_Client.connect()
-                DMX_MVR_X_Client._instance.client.send_commit(commit)
-            except Exception as e:
-                DMX_Log.log.debug(f"problem re_joining {e}")
-                return
+    def send_commit(client, commit):
+        time.sleep(0.3)
+        DMX_MVR_X_Client.disable()
+        DMX_MVR_X_Client._instance = DMX_MVR_X_Client()
+        DMX_MVR_X_Client._instance.selected_client = client
+        try:
+            DMX_MVR_X_Client.connect()
+            DMX_MVR_X_Client._instance.client.send_commit(commit)
 
-    @staticmethod
-    def re_join():
-        if not DMX_MVR_X_Client._instance:
+        except Exception as e:
+            DMX_Log.log.debug(f"problem re_joining {e}")
             return
-        if DMX_MVR_X_Client._instance.client:
-            try:
-                DMX_Log.log.debug("re-joining")
-                if not DMX_MVR_X_Client._instance.client.running:
-                    DMX_MVR_X_Client.connect()
-                DMX_MVR_X_Client._instance.client.join_mvr()
-            except Exception as e:
-                DMX_Log.log.debug(f"problem re_joining {e}")
-                return
 
     @staticmethod
     def connect():
@@ -190,6 +176,8 @@ class DMX_MVR_X_Client:
 
     @staticmethod
     def join(client):
+        time.sleep(0.3)
+        DMX_MVR_X_Client.disable()
         DMX_MVR_X_Client._instance = DMX_MVR_X_Client()
         DMX_MVR_X_Client._instance.selected_client = client
         DMX_MVR_X_Client.connect()
@@ -206,15 +194,14 @@ class DMX_MVR_X_Client:
             DMX_Log.log.info("Disabling MVR client")
 
     @staticmethod
-    def leave():
-        if DMX_MVR_X_Client._instance:
-            if DMX_MVR_X_Client._instance.client:
-                DMX_MVR_X_Client.connect()
-                DMX_MVR_X_Client._instance.client.leave_mvr()
-                time.sleep(0.3)
-                DMX_MVR_X_Client._instance.client.stop()
-            DMX_MVR_X_Client._instance = None
-            DMX_Log.log.info("Disabling MVR")
+    def leave(client):
+        time.sleep(0.3)
+        DMX_MVR_X_Client.disable()
+        DMX_MVR_X_Client._instance = DMX_MVR_X_Client()
+        DMX_MVR_X_Client._instance.selected_client = client
+        DMX_MVR_X_Client.connect()
+        DMX_MVR_X_Client._instance.client.leave_mvr()
+        DMX_Log.log.info("Disabling MVR")
 
 
 class DMX_MVR_X_Server:
@@ -363,7 +350,8 @@ class DMX_MVR_X_WS_Client:
         dmx = bpy.context.scene.dmx
         if msg_type == "MVR_JOIN_RET" and msg_ok is False:
             DMX_Log.log.error("MVR-xchange client refused our connection")
-            dmx.mvrx_enabled = False
+            # dmx.mvrx_enabled = False
+            # TODO: needs testing
 
         if msg_type == "MVR_REQUEST_RET" and msg_ok is False:
             DMX_Log.log.error("MVR-xchange file request declined")

--- a/mvrxchange/mvrx_message.py
+++ b/mvrxchange/mvrx_message.py
@@ -18,11 +18,13 @@
 import json
 import socket
 import struct
-
-# mvr message structures
+import time
+import socket
 
 defined_provider_name = "BlenderDMX"
-defined_station_name = "BlenderDMX station"
+defined_station_name = (
+    f"{defined_provider_name} station {socket.gethostname()}".replace(" ", "_")
+)
 
 
 class mvrx_message:
@@ -125,9 +127,7 @@ class mvrx_message:
     ):
         if message == "MVR_JOIN_RET":
             response = mvrx_message.join_message_ret.copy()
-            response["StationName"] = (
-                f"{defined_station_name} {socket.gethostname()}".replace(" ", "_")
-            )
+            response["StationName"] = f"{defined_station_name}"
             response["StationUUID"] = uuid
             if commits is not None:
                 response["Commits"] = commits
@@ -154,11 +154,14 @@ class mvrx_message:
         elif message == "MVR_REQUEST":
             response = mvrx_message.request_message.copy()
             response["FileUUID"] = file_uuid
-            # response["FromStationUUID"].append(uuid)
+            response[
+                "FromStationUUID"
+            ] = []  # the response seems to stay in memory, reset it
+            response["FromStationUUID"].append(uuid)
             return response
         elif message == "MVR_JOIN":
             response = mvrx_message.join_message.copy()
-            response["StationName"] = f"{defined_station_name} {socket.gethostname()}"
+            response["StationName"] = f"{defined_station_name}"
             response["StationUUID"] = uuid
             if commits is not None:
                 response["Commits"] = commits

--- a/mvrxchange/mvrx_tcp_client.py
+++ b/mvrxchange/mvrx_tcp_client.py
@@ -22,7 +22,6 @@ import time
 from datetime import datetime
 from queue import Queue
 from threading import Thread
-
 import bpy
 
 from ..logging_setup import DMX_Log
@@ -112,6 +111,9 @@ class client(Thread):
     def request_file(self, commit, path):
         self.filepath = path
         self.commit = commit
+        # TODO: this can create a race as the instance is now
+        # short lived. Perhaps we need to store the commit
+        # info in some other place
         if commit.self_requested:  # we need to provide empty UUID in this case
             commit_uuid = ""
         else:

--- a/mvrxchange/mvrx_ws_client.py
+++ b/mvrxchange/mvrx_ws_client.py
@@ -20,7 +20,6 @@ import logging
 import threading
 import time
 from queue import Queue
-
 import bpy
 import websocket
 

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -345,9 +345,9 @@ class DMX_PT_Setup_Extras(Panel):
         layout.operator(
             "wm.url_open", text="User Guide Online", icon="HELP"
         ).url = "https://blenderdmx.eu/docs/faq/"
-        row = layout.row()
-        row.prop(dmx, "mvrx_hostname_in_service")
-        row = layout.row()
+
+        box = layout.column().box()
+        row = box.row()
         row.prop(dmx, "mvrx_per_project_station_uuid")
 
 


### PR DESCRIPTION
Currently, the MVR-xchange in here is able to push data only to one station (and receive data from multiple stations). This PR adds initial support for multistation operation: the "Connect" now shoots the MVR_JOIN message and marks the station in the list as "subscribed", then on commit, we push the commit to all "subscribed" stations.