### PR TITLE
Release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Changelog
 
+### 2.0.5
+
+* MVR-xchange - initial support for multiple connections
+* Progress of Swedish translation by Daniel Nylander
+* Set all protocols as disabled when a blender file is being open
+* Add option to Beam setting to disable Temporal Reprojection in Eevee
+* Ensure that fixture can always be removed from the list of fixtures even if
+  the fixture had been damaged by manual edits
+
 ### 2.0.4
 
 * Translated using Weblate
@@ -8,7 +17,6 @@
     * (French) [CharlyTheSneaky]
 * Adjust mdns service name
 * Fix beam geometry reference processing
-
 
 ### 2.0.3
 

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.0.4"
+version = "2.0.5"
 name = "DMX"
 tagline = "DMX visualization and programming with GDTF/MVR, and Networking"
 maintainer = "Open Stage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "2.0.4"
+version = "2.0.5"
 description = ""
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
# Initial support for multi-station MVR-xchange

This update extends the local (TCP) implementation of the MVR-xchange protocol
to allow exchange of MVR files in a group of stations.

* MVR-xchange - initial support for multiple connections
* Progress of Swedish translation by Daniel Nylander
* Set all protocols as disabled when a blender file is being open
* Add option to Beam setting to disable Temporal Reprojection in Eevee
* Ensure that fixture can always be removed from the list of fixtures even if
  the fixture had been damaged by manual edits
