### PR TITLE
Release v2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ### Changelog
 
+### 2.0.7
+
+* Translated using Weblate:
+    * (Chinese (Simplified Han script)) [大学没毕业]
+    * (Swedish) [Daniel Nylander]
+    * (Polish) [Franciszek Libera]
+* Handle GDTFs with models with both a file (even missing) and a primitive type
+  defined
+* Update most device profiles:
+    * Add Shutter/Strobe
+    * Add thumbnail
+* Adjust name of generic fixture in MVR import
+* Update to pygdtf 2.0.6, update physical values parsing
+
 ### 2.0.6
 
 * Update translations

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.0.6"
+version = "2.0.7"
 name = "DMX"
 tagline = "DMX visualization and programming with GDTF/MVR, and Networking"
 maintainer = "Open Stage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "2.0.6"
+version = "2.0.7"
 description = ""
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
* Translated using Weblate:
    * (Chinese (Simplified Han script)) [大学没毕业]
    * (Swedish) [Daniel Nylander]
    * (Polish) [Franciszek Libera]
* Handle GDTFs with models with both a file (even missing) and a primitive type defined
* Update most device profiles:
    * Add Shutter/Strobe
    * Add thumbnail
* Adjust name of generic fixture in MVR import
* Update to pygdtf 2.0.6, update physical values parsing

