### PR TITLE
Release v2.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Changelog
 
+### 2.0.8
+
+* Prevent MVR persistence during export, to eliminate duplication during export
+* Update to latest pygdtf and pymvr libraries
+* Improvements to Art-Net 4 compatibility, thanks to Michael Wigard
+* Ensure that Programmer Clear sets the fixtures to default values
+* Ensure that fixture is set to default and rendered after being added to the
+  scene
+
 ### 2.0.7
 
 * Translated using Weblate:

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.0.7"
+version = "2.0.8"
 name = "DMX"
 tagline = "DMX visualization and programming with GDTF/MVR, and Networking"
 maintainer = "Open Stage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "2.0.7"
+version = "2.0.8"
 description = ""
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
* Prevent MVR persistence during export, to eliminate duplication during export
* Update to latest pygdtf and pymvr libraries
* Improvements to Art-Net 4 compatibility, thanks to Michael Wigard
* Ensure that Programmer Clear sets the fixtures to default values
* Ensure that fixture is set to default and rendered after being added to the
  scene