### PR TITLE
Optimize rendering for incoming signals (PSN and DMX)

### DIFF
--- a/acn.py
+++ b/acn.py
@@ -71,7 +71,6 @@ class DMX_sACN:
             )
             DMX_Log.log.info(("Joining sACN universe:", universe))
             DMX_sACN._instance.receiver.join_multicast(universe)
-        bpy.app.timers.register(DMX_sACN.run_render)
         dmx.sacn_status = "listen"
 
     @staticmethod
@@ -86,11 +85,3 @@ class DMX_sACN:
             DMX_sACN._instance.data = None
             DMX_sACN._instance = None
         dmx.set_acn_status = "offline"
-
-        if bpy.app.timers.is_registered(DMX_sACN.run_render):
-            bpy.app.timers.unregister(DMX_sACN.run_render)
-
-    @staticmethod
-    def run_render():
-        bpy.context.scene.dmx.render()
-        return 1.0 / 60.0

--- a/artnet.py
+++ b/artnet.py
@@ -270,11 +270,6 @@ class DMX_ArtNet(threading.Thread):
         return b"".join(content)
 
     @staticmethod
-    def run_render():
-        bpy.context.scene.dmx.render()
-        return 1.0 / 60.0
-
-    @staticmethod
     def enable():
         if DMX_ArtNet._thread:
             DMX_Log.log.warning("ArtNet client was already started before.")
@@ -293,16 +288,11 @@ class DMX_ArtNet(threading.Thread):
             return
         DMX_ArtNet._thread.start()
 
-        bpy.app.timers.register(DMX_ArtNet.run_render)
-
         dmx.artnet_status = "listen"
         DMX_Log.log.info("ArtNet client started.")
 
     @staticmethod
     def disable():
-        if bpy.app.timers.is_registered(DMX_ArtNet.run_render):
-            bpy.app.timers.unregister(DMX_ArtNet.run_render)
-
         dmx = bpy.context.scene.dmx
 
         if DMX_ArtNet._thread:

--- a/dmx_temp_data.py
+++ b/dmx_temp_data.py
@@ -151,3 +151,5 @@ class DMX_TempData(PropertyGroup):
             "Distance at which the influence of the light will be set to 0. Value bigger then 23 will break gobo rendering in Eevee Next."
         ),
     )
+
+    render_running: BoolProperty(default=False)

--- a/psn.py
+++ b/psn.py
@@ -57,11 +57,9 @@ class DMX_PSN:
         DMX_PSN._data[uuid] = [
             [],
         ] * 10  # hardcoded to 10 slots
-        if bpy.app.timers.is_registered(DMX_PSN.run_render):
-            # we are already rendering
-            pass
-        else:
-            bpy.app.timers.register(DMX_PSN.run_render)
+
+        dmx = bpy.context.scene.dmx
+        dmx.register_render_toggle(True)
 
     @staticmethod
     def disable(tracker):
@@ -75,12 +73,9 @@ class DMX_PSN:
             DMX_PSN._instances.pop(uuid, None)
             DMX_PSN._data.pop(uuid, None)
             DMX_Log.log.info(f"Disabled PSN {uuid}")
-        if bpy.app.timers.is_registered(DMX_PSN.run_render):
-            if len(DMX_PSN._instances) > 0:
-                # we still need the render
-                pass
-            else:
-                bpy.app.timers.unregister(DMX_PSN.run_render)
+
+        dmx = bpy.context.scene.dmx
+        dmx.register_render_toggle(False)
 
     @staticmethod
     def get_data(tracker_uuid):
@@ -91,8 +86,3 @@ class DMX_PSN:
     @staticmethod
     def set_data(tracker_uuid, slot, data):
         DMX_PSN._data[tracker_uuid][slot] = data
-
-    @staticmethod
-    def run_render():
-        bpy.context.scene.dmx.render()
-        return 1.0 / 60.0


### PR DESCRIPTION
Originally, each DMX subscription created a new render() , which was periodic every 1/60. New approach creates a central timer call, for ArtNet, sACN and PSN protocols. This should optimize performance when several universes are used.