### PR TITLE
mvr: Use masterscale matrix for FocusPoints

### DIFF
--- a/mvr.py
+++ b/mvr.py
@@ -751,7 +751,7 @@ def add_mvr_fixture(
                 mvr_scene,
                 focus_points[0],
                 fixture_idx,
-                Matrix(),
+                mscale,
                 import_globals,
                 focus_fixture.collection,
             )


### PR DESCRIPTION
A default matrix was used for Focuspoints, it is now replaced by the global masterscale matrix.