### PR TITLE
Release 2.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Changelog
 
+### 2.0.12
+
+* Skip migrations when creating a new scene for less verbose console output
+* Added Vwx logo to MVR-xchange UI
+* Updated pymvr library to 1.0.4
+* Improved FocusPoint import from MVR:
+    - import geometries attached to Focus Points
+    - ensure correct position
+    - add classing to be able to hide these geometries
+* Uploaded 3DS wheel version 2.8.0
+* Updated BlenderDMX@LED_PAR_64 to fix strobing
+* Russian translation update (Alex Nadzharov and Yurt Page)
+
 ### 2.0.11
 
 * Translation progress (French, Chinese)

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.0.11"
+version = "2.0.12"
 name = "DMX"
 tagline = "Visualization & programming with GDTF&MVR, OSC, PSN, Networking"
 maintainer = "Open Stage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "2.0.11"
+version = "2.0.12"
 description = ""
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
* Skip migrations when creating a new scene, for less verbose console output
* Added Vwx logo to MVR-xchange UI
* Updated pymvr library to 1.0.4
* Improved FocusPoint import from MVR:
    - import geometries attached to Focus Points
    - ensure correct position
    - add classing to be able to hide these geometries
* Uploaded 3DS wheel version 2.8.0
* Updated BlenderDMX@LED_PAR_64 to fix strobing
* Russian translation update (Alex Nadzharov and Yurt Page)