### PR TITLE
Fix hardcoded expectation for a scene named "Scene" when loading

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -54,14 +54,14 @@ _MSG_BUS_OWNER = object()
 
 
 @bpy.app.handlers.persistent
-def onLoadFile(scene):
+def onLoadFile(dummy): # dummy is the filepath or None
     bpy.msgbus.clear_by_owner(_MSG_BUS_OWNER)
-    if "Scene" in bpy.data.scenes:
-        if "DMX" in bpy.data.scenes["Scene"].collection.children:
-            print("INFO", "File contains DMX show, linking...")
-            bpy.context.scene.dmx.linkFile()
-        else:
-            bpy.context.scene.dmx.unlinkFile()
+    scene = bpy.context.scene
+    if scene and "DMX" in scene.collection.children:
+        print("INFO", "File contains DMX show, linking (haha new code)...")
+        bpy.context.scene.dmx.linkFile()
+    else:
+        bpy.context.scene.dmx.unlinkFile()
 
     # Selection callback
     subscribe_to = bpy.types.LayerObjects, "active"


### PR DESCRIPTION
Noticed this minor oversight when using this awesome addon

When a DMX show is set up in a scene named other than "Scene", the addon fails to find and link the DMX show data, and remains in an unusable state (for that scene):

<img width="384" height="672" alt="image" src="https://github.com/user-attachments/assets/45133410-7a46-438d-a0c3-a6744096e726" />


Instead, linking should just grab the current context's scene and check if it has a collection called DMX