### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Changelog
 
+### 2.2.0
+
+* Initial MVR Class management
+* Initial explicit MVR Layer management
+* Allow to export active layer only
+* Translated using Weblate
+    * Czech - vanous
+    * Swedish - bittin1ddc447d824349b2
+    * German - Ettore Atalan
+
 ### 2.1.9
 
 * Fix hardcoded expectation for a scene named "Scene" when loading - Phillip Dykman

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.1.9"
+version = "2.2.0"
 name = "DMX"
 tagline = "Visualization & programming with GDTF&MVR, OSC, PSN, Networking"
 maintainer = "Open Stage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "2.1.9"
+version = "2.2.0"
 description = "Visualization & programming with GDTF&MVR, OSC, PSN, Networking"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
### 2.2.0

* Initial MVR Class management
* Initial explicit MVR Layer management
* Allow to export active layer only
* Translated using Weblate
    * Czech - vanous
    * Swedish - bittin1ddc447d824349b2
    * German - Ettore Atalan