### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Changelog
 
+### 2.2.1
+
+* Rework MVR import to progressive, allowing canceling during import
+* Translated using Weblate:
+    * Indonesian, Arif Budiman
+    * Chinese, Simplified Han script, 大学没毕业
+    * Swedish, bittin1ddc447d824349b2
+
 ### 2.2.0
 
 * Initial MVR Class management

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 
 * Add changes to CHANGELOG.md
 * update blender_manifest.toml
+* update pyproject.toml
 * Check that ./assets/* doesn't include extra GDTF files or folders
 * Make sure that all used libraries are available via pypi.org
 

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.2.0"
+version = "2.2.1"
 name = "DMX"
 tagline = "Visualization & programming with GDTF&MVR, OSC, PSN, Networking"
 maintainer = "Open Stage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-dmx"
-version = "2.2.0"
+version = "2.2.1"
 description = "Visualization & programming with GDTF&MVR, OSC, PSN, Networking"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
### 2.2.1

## Progressive MVR Import

Importing MVR files - especially large ones - can take some time. This update adds real-time progress feedback and allows the import to be cancelled at any moment by pressing Escape. Because the import process runs in multiple stages, cancelling early may leave some objects unfinished or not yet in their final positions.

* Rework MVR import to progressive, allowing canceling during import
* Translated using Weblate:
    * Indonesian, Arif Budiman
    * Chinese, Simplified Han script, 大学没毕业
    * Swedish, bittin1ddc447d824349b2
