### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Changelog
 
+### 2.3.0
+
+* Rename to BlenderDMX in the BlenderDMX.eu repository
+* Remove 3D animation data during GDTF files import
+* Translated using Weblate:
+    - Tamil: தமிழ்நேரம்
+    - Spanish: Libre
+    - Portuguese: António Oliveira
+    - Kazakh: Azamat Аituganov
+
 ### 2.2.2
 
 * Add progressive MVR loading to MVR-xchange

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,11 +1,12 @@
 schema_version = "1.0.0"
 id = "open_stage_blender_dmx"
-version = "2.2.2"
-name = "DMX"
+version = "2.3.0"
+name = "BlenderDMX"
 tagline = "Visualization & programming with GDTF&MVR, OSC, PSN, Networking"
 maintainer = "Open Stage"
 type = "add-on"
 website = "https://blenderdmx.eu/"
+tags = ["Lighting", "Animation", "Scene", "Import-Export", "Rigging", "Tracking", "Sequencer", "3D View", "Camera"]
 blender_version_min = "4.2.0"
 copyright = ["2021 Open Stage"]
 
@@ -60,3 +61,4 @@ paths_exclude_pattern = [
   "i18n/babel.cfg",
   "i18n/messages.pot",
 ]
+


### PR DESCRIPTION
This is our own repo release with higher version and back to our BlenderDMX name.

### 2.3.0

* Rename to BlenderDMX in the BlenderDMX.eu repository
* Remove 3D animation data during GDTF files import
* Translated using Weblate:
    - Tamil: தமிழ்நேரம்
    - Spanish: Libre
    - Portuguese: António Oliveira
    - Kazakh: Azamat Аituganov
